### PR TITLE
Collision callbacks

### DIFF
--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -84,7 +84,7 @@ class BulletWorld:
                 #print(contact_points[0][5])
                 if contact_points != ():
                     callback[0]()
-                else:
+                elif callback[1] != None: # Call no collision callback 
                     callback[1]()
             if real_time:
                 time.sleep(1/240)
@@ -128,7 +128,7 @@ class BulletWorld:
                 o.set_joint_state(joint, obj.get_joint_state(joint))
         return world
 
-    def register_collision_callback(self, objectA, objectB, callback_collision, callback_no_collision):
+    def register_collision_callback(self, objectA, objectB, callback_collision, callback_no_collision=None):
         """
         This function regsiters can register two callbacks, one if objectA and objectB are in contact
         and another if they are not in contact.

--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -129,6 +129,14 @@ class BulletWorld:
         return world
 
     def register_collision_callback(self, objectA, objectB, callback_collision, callback_no_collision):
+        """
+        This function regsiters can register two callbacks, one if objectA and objectB are in contact
+        and another if they are not in contact.
+        :param A: An object in the BulletWorld
+        :param B: Another object in the BulletWorld
+        :param callback_collision: A function that should be called if the obejcts are in contact
+        :param callback_no_collision: A funtion that should be called if the objects are not in contact
+        """
         self.coll_callbacks[(objectA, objectB)] = (callback_collision, callback_no_collision)
 
 
@@ -180,6 +188,7 @@ class Object:
         :param orientation: The orientation with which the object should be spawned
         :param world: The BulletWorld in which the object should be spawned, if no world is specified the 'current_bullet_world' will be used
         :param color: The color with which the object should be spawned.
+        :param fixed_base: If True the object will be static in the BulletWorld
         """
         self.world = world if world is not None else BulletWorld.current_bullet_world
         self.name = name
@@ -399,6 +408,7 @@ def _load_object(name, path, position, orientation, world, color, fixed_base):
     :param orientation: The orientation in which the object should be spawned
     :param world: The BulletWorld to which the Object should be spawned
     :param color: The color of the object, only used when .obj or .stl file is given
+    :param fixed_base: If the base should be fixed in space or not
     :return: The unique id of the object
     """
     pa = pathlib.Path(path)

--- a/src/pycram/bullet_world_reasoning.py
+++ b/src/pycram/bullet_world_reasoning.py
@@ -104,7 +104,7 @@ def contact(object1, object2, world=None):
     world, world_id = _world_and_id(world)
     p.stepSimulation(world_id)
     con_points = p.getContactPoints(object1.id, object2.id, physicsClientId=world_id)
-
+    
     return con_points is not ()
 
 


### PR DESCRIPTION
# Description 
This PR adds collision callbacks to the BulletWorld. Collision callbacks can be registered with the register_collision_callback method of the BulletWorld class. 
The callback is executed if the two given objects are in contact with one another. Furthermore, a second callback can be provided which is executed if the objects are not in contact. 

## Example 
~~~
from pycram.bullet_world import BulletWorld 

floor = bullet_world.Object("floor", "environment", "resources/plane.urdf")
milk = bullet_world.Object("milk", "object", "milk.obj", [-0.45, -0.5, 1.1])


world = BulletWorld()
world.register_collision_callback(floor, milk, callback)

def callback():
    print("objects are in contact")
~~~