### PR TITLE
ROSBridge singleton fix

### DIFF
--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -13,9 +13,10 @@ import time
 import pathlib
 import logging
 import rospkg
+
+from ros.rosbridge import ros_client
 from .event import Event
 #from .helper import transform
-from ros.rosbridge import ROSBridge
 
 
 class BulletWorld:
@@ -450,8 +451,7 @@ def _load_object(name, path, position, orientation, world, color, ignoreCachedFi
             with open(path, mode="w") as f:
                 f.write(_correct_urdf_string(urdf_string))
         else: # Using the urdf from the parameter server
-            with ROSBridge() as rb:
-                urdf_string = rb.ros_client.get_param(path)
+            urdf_string = ros_client.get_param(path)
             path = cach_dir +  name + ".urdf"
             with open(path, mode="w") as f:
                 f.write(_correct_urdf_string(urdf_string))

--- a/src/pycram/robot_description.py
+++ b/src/pycram/robot_description.py
@@ -3,7 +3,7 @@ from numbers import Number
 import logging
 import re
 
-from ros.rosbridge import ROSBridge
+from ros.rosbridge import ros_client
 
 
 class ChainDescription:
@@ -835,8 +835,7 @@ def update_robot_description(robot_name=None, from_ros=None):
         robot = robot_name
     elif from_ros:
         try:
-            with ROSBridge() as rb:
-                urdf = rb.ros_client.get_param('robot_description')
+            urdf = ros_client.get_param('robot_description')
         except Exception as e:
             logging.error("(robot-description) Could not get robot name from parameter server. Try again.")
             return None

--- a/src/ros/joint_state_publisher.py
+++ b/src/ros/joint_state_publisher.py
@@ -4,6 +4,7 @@ import roslibpy
 import pybullet as pb
 
 from ros.ros_topic_publisher import ROSTopicPublisher
+from ros.rosbridge import ros_client
 
 
 class JointStatePublisher(ROSTopicPublisher):
@@ -11,7 +12,7 @@ class JointStatePublisher(ROSTopicPublisher):
         super().__init__()
         self.world = bullet_world
 
-        self.joint_state_pub = roslibpy.Topic(self.ros_client, joint_state_topic, "sensor_msgs/JointState")
+        self.joint_state_pub = roslibpy.Topic(ros_client, joint_state_topic, "sensor_msgs/JointState")
         self.interval = interval
 
     def _publish(self):

--- a/src/ros/ros_topic_publisher.py
+++ b/src/ros/ros_topic_publisher.py
@@ -2,21 +2,17 @@ import logging
 import threading
 from abc import ABC, abstractmethod
 
-import roslibpy
-
-from ros.rosbridge import ROSBridge
+from ros.rosbridge import ros_client
 
 
 class ROSTopicPublisher(ABC):
     def __init__(self):
-        self.ros_client = ROSBridge().ros_client
-
         self.thread = None
         self.kill_event = threading.Event()
 
     def start_publishing(self):
         logging.info(f"{self.__class__.__name__}::start_publishing: Starting publisher thread...")
-        if not self.ros_client.is_connected:
+        if not ros_client.is_connected:
             raise RuntimeError(f"{self.__class__.__name__}: Cannot start publishing, ROS client not connected")
         if self.kill_event.is_set():
             self.kill_event.clear()

--- a/src/ros/rosbridge.py
+++ b/src/ros/rosbridge.py
@@ -1,61 +1,10 @@
 import os
-from threading import Lock
 from urllib.parse import urlparse
 
 import roslibpy
 
+ros_host = urlparse(os.environ["ROS_MASTER_URI"]).hostname
+rosbridge_port = 9090
 
-class SingletonMeta(type):
-    """
-    This is a thread-safe implementation of Singleton.
-    """
-
-    _instances = {}
-
-    _lock: Lock = Lock()
-    """
-    We now have a lock object that will be used to synchronize threads during
-    first access to the Singleton.
-    """
-
-    def __call__(cls, *args, **kwargs):
-        """
-        Possible changes to the value of the `__init__` argument do not affect
-        the returned instance.
-        """
-        # Now, imagine that the program has just been launched. Since there's no
-        # Singleton instance yet, multiple threads can simultaneously pass the
-        # previous conditional and reach this point almost at the same time. The
-        # first of them will acquire lock and will proceed further, while the
-        # rest will wait here.
-        with cls._lock:
-            # The first thread to acquire the lock, reaches this conditional,
-            # goes inside and creates the Singleton instance. Once it leaves the
-            # lock block, a thread that might have been waiting for the lock
-            # release may then enter this section. But since the Singleton field
-            # is already initialized, the thread won't create a new object.
-            if cls not in cls._instances:
-                instance = super().__call__(*args, **kwargs)
-                cls._instances[cls] = instance
-        return cls._instances[cls]
-
-
-class ROSBridge(metaclass=SingletonMeta):
-    def __init__(self):
-        ros_host, ros_port = self.get_ros_master_host_and_port()
-        self.ros_client = roslibpy.Ros(ros_host, ros_port)
-        self.ros_client.run()
-
-    def __del__(self):
-        self.ros_client.terminate()
-
-    @staticmethod
-    def get_ros_master_host_and_port():
-        uri = urlparse(os.environ["ROS_MASTER_URI"])
-        return uri.hostname, 9090
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+ros_client = roslibpy.Ros(ros_host, rosbridge_port)
+ros_client.run()

--- a/src/ros/tf_broadcaster.py
+++ b/src/ros/tf_broadcaster.py
@@ -15,6 +15,8 @@ import numpy as np
 
 from urdf_parser_py.urdf import URDF
 
+from ros.rosbridge import ros_client
+
 
 class Pose(object):
     def __init__(self, mat):
@@ -43,8 +45,8 @@ class TFBroadcaster(ROSTopicPublisher):
         super().__init__()
         self.world = bullet_world
 
-        self.tf_static_publisher = roslibpy.Topic(self.ros_client, "/tf_static", "geometry_msgs/TransformStamped")
-        self.tf_publisher = roslibpy.Topic(self.ros_client, "/tf", "geometry_msgs/TransformStamped")
+        self.tf_static_publisher = roslibpy.Topic(ros_client, "/tf_static", "geometry_msgs/TransformStamped")
+        self.tf_publisher = roslibpy.Topic(ros_client, "/tf", "geometry_msgs/TransformStamped")
         self.thread = None
         self.kill_event = threading.Event()
         self.interval = interval


### PR DESCRIPTION
In the current implementation of ROSBridge as a singleton metaclass, it was easy to trigger a deadlock: When a class inheriting from SingletonMeta tried to construct a different SingletonMeta in its constructor, the second SingletonMeta instance could never be constructed, because the check for the class happened only AFTER trying to acquire the lock, instead of before.

As an example, consider the following:

```
class A(SingletonMeta):
    pass

class B(SingletonMeta):
    def __init__(self):
        self.a = A()

b = B()     # Deadlock
```
For ROSBridge, a singleton object wasn't even necessary, so I just removed it and simply made it a module with a ros_client global. ros_client is then guaranteed to be instantiated exactly once by the Python import system.