### PR TITLE
Implementation of location designators

### DIFF
--- a/launch/ik_and_description.launch
+++ b/launch/ik_and_description.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="robot" default="pr2" />
+  <arg name="use_knowrob" default="true"/>
 
   <node pkg="kdl_ik_service" type="start_ros_server.py" name="kdl_ik_service" output="screen" />
 
@@ -27,4 +28,8 @@
   <include file="$(find iai_boxy_description)/launch/upload_boxy.launch" />
 -->
 <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch"/>
+
+<group if="$(eval use_knowrob)">
+    <include file="$(find knowrob)/launch/knowrob.launch"/>
+</group>
 </launch>

--- a/src/pycram/knowrob/reasoning.py
+++ b/src/pycram/knowrob/reasoning.py
@@ -9,7 +9,8 @@ def object_type(object_iri: str) -> str:
     """
     :param object_iri: The name (identifier) of the object individual in the KnowRob knowledge base
     """
-    return knowrob.once(f"kb_call(instance_of({atom(object_iri)}, Class))")["Class"]
+    res = knowrob.once(f"kb_call(instance_of({atom(object_iri)}, Class))")
+    return res["Class"]
 
 
 def instances_of(type_: str) -> List[str]:

--- a/src/pycram/location_designator.py
+++ b/src/pycram/location_designator.py
@@ -1,0 +1,55 @@
+from .designator import Designator, DesignatorError, DesignatorDescription
+from typing import List
+
+from .object_designator import ObjectDesignator
+
+
+class LocationDesignator(Designator):
+
+    resolvers = {}
+
+    def __init__(self, description, parent=None):
+        super().__init__(description, parent)
+
+    def next_solution(self):
+        try:
+            self.reference()
+        except DesignatorError:
+            pass
+
+        if self._solutions.has(self._index + 1):
+            desig = LocationDesignator(self._description, self)
+            desig._solutions = self._solutions
+            desig._index = self._index + 1
+            return desig
+
+        return None
+
+    def ground(self):
+        return None
+
+    def get_slots(self):
+        return self._description.get_slots()
+
+    def __str__(self):
+        return "ObjectDesignator({})".format(self._description.__dict__)
+
+
+class LocationDesignatorDescription(DesignatorDescription):
+    pose: List[float]
+
+    def __init__(self, pose=None, resolver="grounding"):
+        super().__init__(resolver)
+        self.pose = pose
+
+
+class ObjectRelativeLocationDesignatorDescription(LocationDesignatorDescription):
+    relative_pose: List[float]
+    reference_object: ObjectDesignator
+    timestamp: float
+
+    def __init__(self, relative_pose: List[float] = None, reference_object: ObjectDesignator = None,
+                 resolver="grounding"):
+        super().__init__(pose=None, resolver=resolver)
+        self.relative_pose = relative_pose
+        self.reference_object = reference_object

--- a/src/pycram/resolver/location_designator_grounding.py
+++ b/src/pycram/resolver/location_designator_grounding.py
@@ -1,0 +1,32 @@
+from pycram.designator import DesignatorError
+from pycram.helper import transform
+from pycram.location_designator import ObjectRelativeLocationDesignatorDescription, LocationDesignator, \
+    LocationDesignatorDescription
+
+
+def ground_object_relative_location(description: ObjectRelativeLocationDesignatorDescription):
+    if description.pose is None:
+        if description.relative_pose is None or description.reference_object is None:
+            raise DesignatorError("Could not ground ObjectRelativeLocationDesignatorDescription: (Relative) pose and reference object must be given")
+        # Fetch the object pose and yield the grounded description
+        obj_grounded = description.reference_object.reference()
+        obj_pose_world = obj_grounded["pose"]
+        description.pose = transform(obj_pose_world, description.relative_pose, local_coords=False)
+
+    return description.__dict__
+
+
+def ground_location(description: LocationDesignatorDescription):
+    if description.pose is None:
+        raise DesignatorError("Could not ground LocationDesignatorDescription: Pose in world coordinates must be given")
+    yield description.__dict__
+
+
+def call_ground(desig):
+    type_to_function = {ObjectRelativeLocationDesignatorDescription: ground_object_relative_location,
+                        LocationDesignatorDescription: ground_location}
+    ground_function = type_to_function[type(desig._description)]
+    return ground_function(desig._description)
+
+
+LocationDesignator.resolvers['grounding'] = call_ground

--- a/src/pycram/resolver/object_designator_grounding.py
+++ b/src/pycram/resolver/object_designator_grounding.py
@@ -17,10 +17,9 @@ def ground_located_object(description: LocatedObjectDesignatorDescription):
             description.name = object_name
             _ground_pose(description)
             yield description.__dict__
-    else:
-        # Fetch the object pose and yield the grounded description
-        _ground_pose(description)
-        return description.__dict__
+    # Fetch the object pose and yield the grounded description
+    _ground_pose(description)
+    yield description.__dict__
 
 
 def call_ground(desig):

--- a/src/pycram/test/test_location_designator_grounding.py
+++ b/src/pycram/test/test_location_designator_grounding.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+import numpy as np
+
+from pycram.knowrob import knowrob
+from pycram.location_designator import ObjectRelativeLocationDesignatorDescription, LocationDesignator, \
+    LocationDesignatorDescription
+from pycram.object_designator import LocatedObjectDesignatorDescription, ObjectDesignator
+from pycram.resolver import location_designator_grounding     # do not remove
+from pycram.resolver import object_designator_grounding       # do not remove
+
+
+class TestLocationDesignatorGrounding(TestCase):
+    def setUp(self) -> None:
+        knowrob.clear_beliefstate()
+        knowrob.once("""
+            kb_project([is_individual(object1), instance_of(object1, objectType)]),
+            tf_logger_enable,
+            mem_tf_set(object1, world, [1.0, 2.0, 0.5], [0.0, 0.0, 0.0, 1.0], 4.0)""")
+
+    def tearDown(self) -> None:
+        knowrob.clear_beliefstate()
+
+    def test_ground_object_relative_location(self):
+        """
+        Test grounding of ObjectRelativeLocationDesignator (generation of absolute poses in world frame, given an
+        object and a relative transformation
+        """
+        object_desig = ObjectDesignator(LocatedObjectDesignatorDescription(name="object1"))
+        desc = ObjectRelativeLocationDesignatorDescription(relative_pose=[0.2, 0.1, 1.3, 0.0, 0.0, 0.0, 1.0],
+                                                           reference_object=object_desig)
+        desig = LocationDesignator(desc)
+        sol = desig.reference()
+        pose_world = sol["pose"]
+        self.assertTrue(np.allclose(np.array(pose_world), np.array([1.2, 2.1, 1.8, 0.0, 0.0, 0.0, 1.0])))
+
+    def test_ground_location(self):
+        """
+        Test default grounding of LocationDesignator
+        """
+        desc = LocationDesignatorDescription(pose=[1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0])
+        desig = LocationDesignator(desc)
+        sol = desig.reference()
+        pose_world = sol["pose"]
+        self.assertTrue(np.allclose(np.array(pose_world), np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0])))


### PR DESCRIPTION
Includes a unit test and a KnowRob-based resolver.

Launch `ik_and_description.launch` before running the unit test in `src/pycram/test/test_location_designator_grounding.py` because it requires KnowRob. 

To use the KnowRob-based designator resolution, you need https://github.com/code-iai/neem-interface/pull/1 in neem-interface.