### PR TITLE
Clear urdf from cache when load fails

### DIFF
--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -48,6 +48,9 @@ class BulletWorld:
         self.type = type
         self._gui_thread = Gui(self, type)
         self._gui_thread.start()
+        # This disables file caching from PyBullet, since this would also cache
+        # files that can not be loaded
+        p.setPhysicsEngineParameter(enableFileCaching=0)
         time.sleep(1) # 0.1
         self.last_bullet_world = BulletWorld.current_bullet_world
         BulletWorld.current_bullet_world = self
@@ -491,6 +494,8 @@ def _load_object(name, path, position, orientation, world, color, ignoreCachedFi
     except p.error as e:
         print(e)
         logging.error("The File could not be loaded. Plese note that the path has to be either a URDF, stl or obj file or the name of an URDF string on the parameter server.")
+        os.remove(path)
+        raise(e)
         #print(f"{bcolors.BOLD}{bcolors.WARNING}The path has to be either a path to a URDf file, stl file, obj file or the name of a URDF on the parameter server.{bcolors.ENDC}")
 
 

--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -492,7 +492,6 @@ def _load_object(name, path, position, orientation, world, color, ignoreCachedFi
         obj = p.loadURDF(path, basePosition=position, baseOrientation=orientation, physicsClientId=world_id)
         return obj
     except p.error as e:
-        print(e)
         logging.error("The File could not be loaded. Plese note that the path has to be either a URDF, stl or obj file or the name of an URDF string on the parameter server.")
         os.remove(path)
         raise(e)

--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -474,7 +474,7 @@ def _load_object(name, path, position, orientation, world, color, ignoreCachedFi
     if re.match("[a-zA-Z_0-9].[a-zA-Z0-9]", path):
         for dir in world.data_directory:
             path = get_path_from_data_dir(path, dir)
-            if path: break 
+            if path: break
     #rospack = rospkg.RosPack()
     #cach_dir = rospack.get_path('pycram') + '/resources/cached/'
     cach_dir = world.data_directory[0] + '/cached/'
@@ -490,7 +490,11 @@ def _load_object(name, path, position, orientation, world, color, ignoreCachedFi
                 urdf_string = f.read()
             path = cach_dir +  pa.name
             with open(path, mode="w") as f:
-                f.write(_correct_urdf_string(urdf_string))
+                try:
+                    f.write(_correct_urdf_string(urdf_string))
+                except rospkg.ResourceNotFound as e:
+                    os.remove(path)
+                    raise e
         else: # Using the urdf from the parameter server
             urdf_string = rospy.get_param(path)
             path = cach_dir +  name + ".urdf"

--- a/src/pycram/robot_description.py
+++ b/src/pycram/robot_description.py
@@ -833,7 +833,7 @@ def update_robot_description(robot_name=None, from_ros=None):
         except Exception as e:
             logging.error("(robot-description) Could not get robot name from parameter server. Try again.")
             return None
-        res = re.findall(r"robot\ *name\ *=\ *\"\ *[a-zA-Z_1-9]*\ *\"", urdf)
+        res = re.findall(r"robot\ *name\ *=\ *\"\ *[a-zA-Z_0-9]*\ *\"", urdf)
         if len(res) == 1:
             begin = res[0].find("\"")
             end = res[0][begin + 1:].find("\"")


### PR DESCRIPTION
# Description 
This PR adds quality of life for loading objects to the BulletWorlld. 
These qos changes are:

Code is added that deletes the created URDF in the PyCRAM cache if loading of the URDF fails. Either if the URDF is malformed or the lookup of ROS packaged failes. This is done to avoid that a faulty file remains in cache while the user fixed the actual file in the resources directory. Additionally the file caching of PyBullet is disabled since this caching would also cache faulty files which can not be removed by a user, resulting in the same problem this PR is trying to solve. 

Also PyCRAM now raises an error if loading of a file fails directly at the point in code where the loading happens and not further down when the program tries to get link and joint information. 

Furthermore there is now a standard data directory in which BulletWorld looks for files if only a file name is given, this is the "resource" directory in the PyCRAM repo. It is also possible to add more directories to search in. 

PyCRAM now also detects if the loaded object is the robot corresponding to the loaded robot description and automatically assigns this object to the ```robot``` variable in the BulletWorld clas.



