### PR TITLE
[costmaps] moved rayTesting to the shadow world

### DIFF
--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -357,7 +357,7 @@ class OccupancyCostmap(Costmap):
         # 16383 is the maximal number of rays that can be processed in a batch
         i = 0
         j = 0
-        for n in self._chunks(np.array(rays), 8190):
+        for n in self._chunks(np.array(rays), 16380):
             with Use_shadow_world():
                 r_t = p.rayTestBatch(n[:, 0], n[:, 1], numThreads=0, physicsClientId=BulletWorld.current_bullet_world.client_id)
 

--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -357,16 +357,16 @@ class OccupancyCostmap(Costmap):
         # 16383 is the maximal number of rays that can be processed in a batch
         i = 0
         j = 0
-        for n in self._chunks(np.array(rays), 16383):
-            r_t = p.rayTestBatch(n[:, 0], n[:, 1], numThreads=0)
-            if r_t is None:
-                r_t = p.rayTestBatch(n[:, 0], n[:, 1], numThreads=0)
-            j += len(n)
-            if BulletWorld.robot:
-                res[i:j] = [1 if ray[0] == -1 or ray[0] == BulletWorld.robot.id else 0 for ray in r_t]
-            else:
-                res[i:j] = [1 if ray[0] == -1 else 0 for ray in r_t]
-            i += len(n)
+        for n in self._chunks(np.array(rays), 8190):
+            with Use_shadow_world():
+                r_t = p.rayTestBatch(n[:, 0], n[:, 1], numThreads=0, physicsClientId=BulletWorld.current_bullet_world.client_id)
+
+                j += len(n)
+                if BulletWorld.robot:
+                    res[i:j] = [1 if ray[0] == -1 or ray[0] == BulletWorld.robot.id else 0 for ray in r_t]
+                else:
+                    res[i:j] = [1 if ray[0] == -1 else 0 for ray in r_t]
+                i += len(n)
 
         res = np.flip(np.reshape(np.array(res), (size, size)))
 


### PR DESCRIPTION
This PR should finally solve the rayTest bug. The problem seemed to be that the shadow world was introduced in a previous PR. The presence of two simulations at a time was what caused this error, to solve the bug rayTesting was moved to the shadow world. 

The implementation was tested on 10000 runs of creating the Occupancy costmap. However, to be sure this is fixed in the long run the test case which creates 300 Occupancy Costmaps is kept.