### PR TITLE
[bullet-world] fixes in remove method to avoid crashes

### DIFF
--- a/src/pycram/bullet_world.py
+++ b/src/pycram/bullet_world.py
@@ -775,7 +775,10 @@ class Object:
         # has a reference to the shadow world
         if self.world.shadow_world != None:
             self.world.world_sync.remove_obj_queue.put(self)
+            self.world.world_sync.remove_obj_queue.join()
         p.removeBody(self.id, physicsClientId=self.world.client_id)
+        if BulletWorld.robot == self:
+            BulletWorld.robot = None
 
     def attach(self, object: Object, link: Optional[str] = None, loose: Optional[bool] = False) -> None:
         """


### PR DESCRIPTION
# Description 
Some fixes for the remove method of Objects. These fixes are:
    * Set the BulletWorld.robot to None if the removed Object was the robot 
    * Wait for the shadow object to be removed before removing  the normal object to avoid crashes of the world sync thread