### PR TITLE
[ros/tf-broadcast] Fixed time in published TF frames

### DIFF
--- a/src/pycram/ros/tf_broadcaster.py
+++ b/src/pycram/ros/tf_broadcaster.py
@@ -25,7 +25,7 @@ class TFBroadcaster:
 
         self.tf_static_publisher = rospy.Publisher("/tf_static", TFMessage, queue_size=10)
         self.tf_publisher = rospy.Publisher("/tf", TFMessage, queue_size=10)
-        self.thread = threading.Thread(target=self._publish)
+        self.thread = threading.Thread(target=self._publish, daemon=True)
         self.kill_event = threading.Event()
         self.interval = interval
 
@@ -52,9 +52,11 @@ class TFBroadcaster:
         """
         for obj in self.world.objects:
             pose = obj.get_pose()
+            pose.header.stamp = rospy.Time.now()
             self._publish_pose(obj.tf_frame, pose)
             for link in obj.links.keys():
                 link_pose = obj.get_link_pose(link)
+                link_pose.header.stamp = rospy.Time.now()
                 self._publish_pose(obj.get_link_tf_frame(link), link_pose)
 
     def _update_static_odom(self) -> None:


### PR DESCRIPTION
Published TF messages now have the correct time stamp, eliminating the TF_REPEATED_DATA error that was occuring.