### PR TITLE
[binder]: added specific requirements for launch

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR ${PYCRAM_WS}/src/
 COPY --chown=${NB_USER}:users . pycram/
 RUN vcs import --input pycram/binder/pycram-http.rosinstall --recursive
 
-RUN pip install --requirement ${PYCRAM_WS}/src/pycram/requirements.txt --user 
+RUN pip install --requirement ${PYCRAM_WS}/src/pycram/binder/requirements.txt --user 
 
 # Remove double numpy version 
 RUN pip uninstall numpy -y

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,18 @@
+gitpython>=3.1.37
+pybullet~=3.2.5
+rospkg~=1.4.0
+roslibpy~=1.2.1
+# rospy~=1.14.11
+pathlib~=1.0.1
+numpy>=1.21.1
+pytransform3d~=1.9.1
+# tf~=1.12.1
+# actionlib~=1.12.1
+urdf-parser-py~=0.0.3
+graphviz
+anytree>=2.8.0
+SQLAlchemy>=2.0.9
+tqdm==4.66.1
+psutil==5.9.7
+lxml==4.9.1
+rdflib==7.0.0


### PR DESCRIPTION
Added a specific requirements file for binder as the current numpy version (1.24.3) is incompatible.