### PR TITLE
[binder]: removed uninstallation of numpy

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -9,10 +9,6 @@ RUN vcs import --input pycram/binder/pycram-http.rosinstall --recursive
 
 RUN pip install --requirement ${PYCRAM_WS}/src/pycram/binder/requirements.txt --user 
 
-# Remove double numpy version 
-RUN pip uninstall numpy -y
-RUN pip install --upgrade pip
-
 COPY --chown=${NB_USER}:users binder/me ${PYCRAM_WS}/src/me
 
 USER root


### PR DESCRIPTION
Numpy is no longer being uninstalled during binder launch as this was to prevent two numpy installations with different versions.
Since this is resolved, the uninstall needs to be removed to ensure numpy is still installed in the environment.  