### PR TITLE
Fix for Attachment constraint deletion issue

### DIFF
--- a/src/pycram/description.py
+++ b/src/pycram/description.py
@@ -236,7 +236,8 @@ class Link(ObjectEntity, LinkDescription, ABC):
         """
         self.world.remove_constraint(self.constraint_ids[child_link])
         del self.constraint_ids[child_link]
-        del child_link.constraint_ids[self]
+        if self in child_link.constraint_ids.keys():
+            del child_link.constraint_ids[self]
 
     @property
     def is_root(self) -> bool:


### PR DESCRIPTION
On deletion of constraints, there needed to be a check that the constraint id exists first.