### PR TITLE
[failure handling]  A subclass of FailureHandling

### DIFF
--- a/src/pycram/failure_handling.py
+++ b/src/pycram/failure_handling.py
@@ -1,5 +1,8 @@
 from .designator import DesignatorDescription
 from .plan_failures import PlanFailure
+from threading import Lock
+from typing import Union
+from .language import Language, Monitor
 
 
 class FailureHandling:
@@ -11,7 +14,7 @@ class FailureHandling:
     to be extended by subclasses that implement specific failure handling behaviors.
     """
 
-    def __init__(self, designator_description: DesignatorDescription):
+    def __init__(self, designator_description: Union[DesignatorDescription, Monitor]):
         """
         Initializes a new instance of the FailureHandling class.
 
@@ -79,5 +82,75 @@ class Retry(FailureHandling):
                     raise e
 
 
+class RetryMonitor(FailureHandling):
+    """
+    A subclass of FailureHandling that implements a retry mechanism that works with a Monitor.
+    This class represents a specific failure handling strategy that allows us to retry a demo that is
+    being monitored, in case that monitoring condition is triggered.
+    Attributes:
+        max_tries (int): The maximum number of attempts to retry the action.
+    Inherits:
+        All attributes and methods from the FailureHandling class.
+    Overrides:
+        perform(): Implements the retry logic.
+    """
 
+    def __init__(self, designator_description: Monitor, max_tries: int = 3):
+        """
+        Initializes a new instance of the Retry class.
+        Args:
+            designator_description (DesignatorDescription): The description or context
+            of the task or process for which the retry mechanism is being set up.
+            max_tries (int, optional): The maximum number of attempts to retry. Defaults to 3.
+        """
+        super().__init__(designator_description)
+        self.max_tries = max_tries
+        self.lock = Lock()
 
+    def perform(self):
+        """
+        Implementation of the retry mechanism.
+        This method attempts to perform the Monitor + plan specified in the designator_description.
+        If the action fails, it is retried up to max_tries times. If all attempts fail,
+        the last exception is raised. In every loop, we need to clear the kill_event, and set all
+        relevant 'interrupted' variables to False, to make sure the Monitor and plan are executed
+        properly again
+        Raises:
+            PlanFailure: If all retry attempts fail.
+        Returns:
+            The state of the execution performed, as well as a flattened list of the results, in the correct order
+        """
+
+        def reset_interrupted(child):
+            if hasattr(child, "interrupted"):
+                child.interrupted = False
+            for sub_child in getattr(child, "children", []):
+                reset_interrupted(sub_child)
+
+        def flatten(result):
+            flattened_list = []
+            for item in result:
+                if isinstance(item, list):
+                    flattened_list.extend(item)
+                elif isinstance(item, tuple):
+                    flattened_list.append(item)
+                else:
+                    flattened_list.append(item)
+            return flattened_list
+
+        status, res = None, None
+        with self.lock:
+            tries = 0
+            while True:
+                self.designator_description.kill_event.clear()
+                self.designator_description.interrupted = False
+                for child in self.designator_description.children:
+                    reset_interrupted(child)
+                try:
+                    status, res = self.designator_description.perform()
+                    break
+                except PlanFailure as e:
+                    tries += 1
+                    if tries >= self.max_tries:
+                        raise e
+        return status, flatten(res)

--- a/src/pycram/failure_handling.py
+++ b/src/pycram/failure_handling.py
@@ -5,7 +5,7 @@ from typing import Union
 from .language import Language, Monitor
 
 
-class FailureHandling:
+class FailureHandling(Language):
     """
     Base class for failure handling mechanisms in automated systems or workflows.
 
@@ -85,38 +85,60 @@ class Retry(FailureHandling):
 class RetryMonitor(FailureHandling):
     """
     A subclass of FailureHandling that implements a retry mechanism that works with a Monitor.
+
     This class represents a specific failure handling strategy that allows us to retry a demo that is
     being monitored, in case that monitoring condition is triggered.
+
     Attributes:
         max_tries (int): The maximum number of attempts to retry the action.
+        recovery (dict): A dictionary that maps exception types to recovery actions
+
     Inherits:
         All attributes and methods from the FailureHandling class.
+
     Overrides:
         perform(): Implements the retry logic.
     """
 
-    def __init__(self, designator_description: Monitor, max_tries: int = 3):
+    def __init__(self, designator_description: Monitor, max_tries: int = 3, recovery: dict = None):
         """
         Initializes a new instance of the Retry class.
+
         Args:
             designator_description (DesignatorDescription): The description or context
             of the task or process for which the retry mechanism is being set up.
             max_tries (int, optional): The maximum number of attempts to retry. Defaults to 3.
+            recovery (dict, optional): A dictionary that maps exception types to recovery actions. Defaults to None.
         """
         super().__init__(designator_description)
         self.max_tries = max_tries
         self.lock = Lock()
+        if recovery is None:
+            self.recovery = {}
+        else:
+            if not isinstance(recovery, dict):
+                raise ValueError(
+                    "Recovery must be a dictionary with exception types as keys and Language instances as values.")
+            for key, value in recovery.items():
+                if not issubclass(key, BaseException):
+                    raise TypeError("Keys in the recovery dictionary must be exception types.")
+                if not isinstance(value, Language):
+                    raise TypeError("Values in the recovery dictionary must be instances of the Language class.")
+            self.recovery = recovery
 
     def perform(self):
         """
         Implementation of the retry mechanism.
+
         This method attempts to perform the Monitor + plan specified in the designator_description.
         If the action fails, it is retried up to max_tries times. If all attempts fail,
         the last exception is raised. In every loop, we need to clear the kill_event, and set all
         relevant 'interrupted' variables to False, to make sure the Monitor and plan are executed
         properly again
+
         Raises:
             PlanFailure: If all retry attempts fail.
+
         Returns:
             The state of the execution performed, as well as a flattened list of the results, in the correct order
         """
@@ -132,8 +154,6 @@ class RetryMonitor(FailureHandling):
             for item in result:
                 if isinstance(item, list):
                     flattened_list.extend(item)
-                elif isinstance(item, tuple):
-                    flattened_list.append(item)
                 else:
                     flattened_list.append(item)
             return flattened_list
@@ -153,4 +173,7 @@ class RetryMonitor(FailureHandling):
                     tries += 1
                     if tries >= self.max_tries:
                         raise e
+                    exception_type = type(e)
+                    if exception_type in self.recovery:
+                        self.recovery[exception_type].perform()
         return status, flatten(res)

--- a/src/pycram/language.py
+++ b/src/pycram/language.py
@@ -1,7 +1,7 @@
 # used for delayed evaluation of typing until python 3.11 becomes mainstream
 from __future__ import annotations
 
-import queue
+from queue import Queue
 import rospy
 from typing_extensions import Iterable, Optional, Callable, Dict, Any, List, Union, Tuple
 from anytree import NodeMixin, Node, PreOrderIter
@@ -261,7 +261,7 @@ class Monitor(Language):
         """
         super().__init__(None, None)
         self.kill_event = threading.Event()
-        self.exception_queue = queue.Queue()
+        self.exception_queue = Queue()
         if callable(condition):
             self.condition = Fluent(condition)
         elif isinstance(condition, Fluent):
@@ -282,8 +282,10 @@ class Monitor(Language):
                     cond = self.condition.get_value()
                     if cond:
                         for child in self.children:
-                            if hasattr(child, 'interrupt'):
+                            try:
                                 child.interrupt()
+                            except NotImplementedError:
+                                pass
                         if isinstance(cond, type) and issubclass(cond, Exception):
                             self.exception_queue.put(cond)
                         else:

--- a/src/pycram/language.py
+++ b/src/pycram/language.py
@@ -1,8 +1,9 @@
 # used for delayed evaluation of typing until python 3.11 becomes mainstream
 from __future__ import annotations
 
-import time
-from typing_extensions import Iterable, Optional, Callable, Dict, Any, List, Union
+import queue
+import rospy
+from typing_extensions import Iterable, Optional, Callable, Dict, Any, List, Union, Tuple
 from anytree import NodeMixin, Node, PreOrderIter
 
 from pycram.datastructures.enums import State
@@ -260,6 +261,7 @@ class Monitor(Language):
         """
         super().__init__(None, None)
         self.kill_event = threading.Event()
+        self.exception_queue = queue.Queue()
         if callable(condition):
             self.condition = Fluent(condition)
         elif isinstance(condition, Fluent):
@@ -267,27 +269,42 @@ class Monitor(Language):
         else:
             raise AttributeError("The condition of a Monitor has to be a Callable or a Fluent")
 
-    def perform(self):
+    def perform(self) -> Tuple[State, Any]:
         """
         Behavior of the Monitor, starts a new Thread which checks the condition and then performs the attached language
         expression
 
-        :return: The result of the attached language expression
+        :return: The state of the attached language expression, as well as a list of the results of the children
         """
         def check_condition():
-            while not self.condition.get_value() and not self.kill_event.is_set():
-                time.sleep(0.1)
-            if self.kill_event.is_set():
-                return
-            for child in self.children:
-                child.interrupt()
+            while not self.kill_event.is_set():
+                try:
+                    cond = self.condition.get_value()
+                    if cond:
+                        for child in self.children:
+                            if hasattr(child, 'interrupt'):
+                                child.interrupt()
+                        if isinstance(cond, type) and issubclass(cond, Exception):
+                            self.exception_queue.put(cond)
+                        else:
+                            self.exception_queue.put(PlanFailure("Condition met in Monitor"))
+                        return
+                except Exception as e:
+                    self.exception_queue.put(e)
+                    return
+                rospy.sleep(0.1)
 
         t = threading.Thread(target=check_condition)
         t.start()
-        res = self.children[0].perform()
-        self.kill_event.set()
-        t.join()
-        return res
+        try:
+            state, result = self.children[0].perform()
+            if not self.exception_queue.empty():
+                print("Raising PlanFailure")
+                raise self.exception_queue.get()
+        finally:
+            self.kill_event.set()
+            t.join()
+        return state, result
 
     def interrupt(self) -> None:
         """
@@ -303,28 +320,35 @@ class Sequential(Language):
     Instead, the exception is saved to a list of all exceptions thrown during execution and returned.
 
     Behaviour:
-        Return the state :py:attr:`~State.SUCCEEDED` *iff* all children are executed without exception.
-        In any other case the State :py:attr:`~State.FAILED` will be returned.
+        Returns a tuple containing the final state of execution (SUCCEEDED, FAILED) and a list of results from each
+        child's perform() method. The state is :py:attr:`~State.SUCCEEDED` *iff* all children are executed without
+        exception. In any other case the State :py:attr:`~State.FAILED` will be returned.
     """
 
-    def perform(self) -> State:
+    def perform(self) -> Tuple[State, List[Any]]:
         """
         Behaviour of Sequential, calls perform() on each child sequentially
 
-        :return: The state according to the behaviour described in :func:`Sequential`
+        :return: The state and list of results according to the behaviour described in :func:`Sequential`
         """
+        children_return_values = [None] * len(self.children)
         try:
-            for child in self.children:
+            for index, child in enumerate(self.children):
                 if self.interrupted:
                     if threading.get_ident() in self.block_list:
                         self.block_list.remove(threading.get_ident())
-                    return
+                    return State.FAILED, children_return_values
                 self.root.executing_thread[child] = threading.get_ident()
-                child.resolve().perform()
+                ret_val = child.resolve().perform()
+                if isinstance(ret_val, tuple):
+                    child_state, child_result = ret_val
+                    children_return_values[index] = child_result
+                else:
+                    children_return_values[index] = ret_val
         except PlanFailure as e:
             self.root.exceptions[self] = e
-            return State.FAILED
-        return State.SUCCEEDED
+            return State.FAILED, children_return_values
+        return State.SUCCEEDED, children_return_values
 
     def interrupt(self) -> None:
         """
@@ -343,33 +367,40 @@ class TryInOrder(Language):
     Instead, the exception is saved to a list of all exceptions thrown during execution and returned.
 
     Behaviour:
-        Returns the State :py:attr:`~State.SUCCEEDED` if one or more children are executed without
+        Returns a tuple containing the final state of execution (SUCCEEDED, FAILED) and a list of results from each
+        child's perform() method. The state is :py:attr:`~State.SUCCEEDED` if one or more children are executed without
         exception. In the case that all children could not be executed the State :py:attr:`~State.FAILED` will be returned.
     """
 
-    def perform(self) -> State:
+    def perform(self) -> Tuple[State, List[Any]]:
         """
         Behaviour of TryInOrder, calls perform() on each child sequentially and catches raised exceptions.
 
-        :return: The state according to the behaviour described in :func:`TryInOrder`
+        :return: The state and list of results according to the behaviour described in :func:`TryInOrder`
         """
         failure_list = []
-        for child in self.children:
+        children_return_values = [None] * len(self.children)
+        for index, child in enumerate(self.children):
             if self.interrupted:
                 if threading.get_ident() in self.block_list:
                     self.block_list.remove(threading.get_ident())
-                return
+                return State.INTERRUPTED, children_return_values
             try:
-                child.resolve().perform()
+                ret_val = child.resolve().perform()
+                if isinstance(ret_val, tuple):
+                    child_state, child_result = ret_val
+                    children_return_values[index] = child_result
+                else:
+                    children_return_values[index] = ret_val
             except PlanFailure as e:
                 failure_list.append(e)
         if len(failure_list) > 0:
             self.root.exceptions[self] = failure_list
         if len(failure_list) == len(self.children):
             self.root.exceptions[self] = failure_list
-            return State.FAILED
+            return State.FAILED, children_return_values
         else:
-            return State.SUCCEEDED
+            return State.SUCCEEDED, children_return_values
 
     def interrupt(self) -> None:
         """
@@ -388,19 +419,27 @@ class Parallel(Language):
     exceptions during execution will be caught, saved to a list and returned upon end.
 
     Behaviour:
-        Returns the State :py:attr:`~State.SUCCEEDED` *iff* all children could be executed without an exception. In any
-        other case the State :py:attr:`~State.FAILED` will be returned.
+        Returns a tuple containing the final state of execution (SUCCEEDED, FAILED) and a list of results from
+        each child's perform() method. The state is :py:attr:`~State.SUCCEEDED` *iff* all children could be executed without
+        an exception. In any other case the State :py:attr:`~State.FAILED` will be returned.
+
     """
 
-    def perform(self) -> State:
+    def perform(self) -> Tuple[State, List[Any]]:
         """
         Behaviour of Parallel, creates a new thread for each child and calls perform() of the child in the respective
         thread.
 
-        :return: The state according to the behaviour described in :func:`Parallel`
-        """
+        :return: The state and list of results according to the behaviour described in :func:`Parallel`
 
-        def lang_call(child_node):
+        """
+        results = [None] * len(self.children)
+        self.threads: List[threading.Thread] = []
+        state = State.SUCCEEDED
+        results_lock = threading.Lock()
+
+        def lang_call(child_node, index):
+            nonlocal state
             if ("DesignatorDescription" in [cls.__name__ for cls in child_node.__class__.__mro__]
                     and self.__class__.__name__ not in self.do_not_use_giskard):
                 if self not in giskard.par_threads.keys():
@@ -409,26 +448,39 @@ class Parallel(Language):
                     giskard.par_threads[self].append(threading.get_ident())
             try:
                 self.root.executing_thread[child] = threading.get_ident()
-                child_node.resolve().perform()
+                result = child_node.resolve().perform()
+                if isinstance(result, tuple):
+                    child_state, child_result = result
+                    with results_lock:
+                        results[index] = child_result
+                else:
+                    with results_lock:
+                        results[index] = result
             except PlanFailure as e:
+                nonlocal state
+                with results_lock:
+                    state = State.FAILED
                 if self in self.root.exceptions.keys():
                     self.root.exceptions[self].append(e)
                 else:
                     self.root.exceptions[self] = [e]
 
-        for child in self.children:
+        for index, child in enumerate(self.children):
             if self.interrupted:
+                state = State.FAILED
                 break
-            t = threading.Thread(target=lambda: lang_call(child))
+            t = threading.Thread(target=lambda: lang_call(child, index))
             t.start()
             self.threads.append(t)
         for thread in self.threads:
             thread.join()
-            if thread.ident in self.block_list:
-                self.block_list.remove(thread.ident)
+        with results_lock:
+            for thread in self.threads:
+                if thread.ident in self.block_list:
+                    self.block_list.remove(thread.ident)
         if self in self.root.exceptions.keys() and len(self.root.exceptions[self]) != 0:
-            return State.FAILED
-        return State.SUCCEEDED
+            state = State.FAILED
+        return state, results
 
     def interrupt(self) -> None:
         """
@@ -448,20 +500,24 @@ class TryAll(Language):
     exceptions during execution will be caught, saved to a list and returned upon end.
 
     Behaviour:
-        Returns the State :py:attr:`~State.SUCCEEDED` if one or more children could be executed without raising an
-        exception. If all children fail the State :py:attr:`~State.FAILED` will be returned.
+        Returns a tuple containing the final state of execution (SUCCEEDED, FAILED) and a list of results from each
+        child's perform() method. The state is :py:attr:`~State.SUCCEEDED` if one or more children could be executed
+        without raising an exception. If all children fail the State :py:attr:`~State.FAILED` will be returned.
     """
 
-    def perform(self) -> State:
+    def perform(self) -> Tuple[State, List[Any]]:
         """
         Behaviour of TryAll, creates a new thread for each child and executes all children in their respective threads.
 
-        :return: The state according to the behaviour described in :func:`TryAll`
+        :return: The state and list of results according to the behaviour described in :func:`TryAll`
         """
+        results = [None] * len(self.children)
+        results_lock = threading.Lock()
+        state = State.SUCCEEDED
         self.threads: List[threading.Thread] = []
         failure_list = []
 
-        def lang_call(child_node):
+        def lang_call(child_node, index):
             if ("DesignatorDescription" in [cls.__name__ for cls in child_node.__class__.__mro__]
                     and self.__class__.__name__ not in self.do_not_use_giskard):
                 if self not in giskard.par_threads.keys():
@@ -469,27 +525,37 @@ class TryAll(Language):
                 else:
                     giskard.par_threads[self].append(threading.get_ident())
             try:
-                child_node.resolve().perform()
+                result = child_node.resolve().perform()
+                if isinstance(result, tuple):
+                    child_state, child_result = result
+                    with results_lock:
+                        results[index] = child_result
+                else:
+                    with results_lock:
+                        results[index] = result
             except PlanFailure as e:
                 failure_list.append(e)
                 if self in self.root.exceptions.keys():
                     self.root.exceptions[self].append(e)
                 else:
                     self.root.exceptions[self] = [e]
-
-        for child in self.children:
-            t = threading.Thread(target=lambda: lang_call(child))
-            t.start()
+        for index, child in enumerate(self.children):
+            if self.interrupted:
+                state = State.FAILED
+                break
+            t = threading.Thread(target=lambda: lang_call(child, index))
             self.threads.append(t)
+            t.start()
         for thread in self.threads:
             thread.join()
-            if thread.ident in self.block_list:
-                self.block_list.remove(thread.ident)
+        with results_lock:
+            for thread in self.threads:
+                if thread.ident in self.block_list:
+                    self.block_list.remove(thread.ident)
         if len(self.children) == len(failure_list):
             self.root.exceptions[self] = failure_list
-            return State.FAILED
-        else:
-            return State.SUCCEEDED
+            state = State.FAILED
+        return state, results
 
     def interrupt(self) -> None:
         """
@@ -529,9 +595,16 @@ class Code(Language):
         """
         Execute the code with its arguments
 
-        :returns: Anything that the function associated with this object will return.
+        :returns: State.SUCCEEDED, and anything that the function associated with this object will return.
         """
-        return self.function(**self.kwargs)
+        child_state = State.SUCCEEDED
+        ret_val = self.function(**self.kwargs)
+        if isinstance(ret_val, tuple):
+            child_state, child_result = ret_val
+        else:
+            child_result = ret_val
+
+        return child_state, child_result
 
     def interrupt(self) -> None:
         raise NotImplementedError

--- a/src/pycram/language.py
+++ b/src/pycram/language.py
@@ -299,7 +299,6 @@ class Monitor(Language):
         try:
             state, result = self.children[0].perform()
             if not self.exception_queue.empty():
-                print("Raising PlanFailure")
                 raise self.exception_queue.get()
         finally:
             self.kill_event.set()

--- a/test/test_language.py
+++ b/test/test_language.py
@@ -4,8 +4,9 @@ import unittest
 from pycram.designators.action_designator import *
 from pycram.designators.object_designator import BelieveObject
 from pycram.datastructures.enums import ObjectType, State
+from pycram.failure_handling import RetryMonitor
 from pycram.fluent import Fluent
-from pycram.plan_failures import PlanFailure
+from pycram.plan_failures import PlanFailure, NotALanguageExpression
 from pycram.datastructures.pose import Pose
 from pycram.language import Sequential, Language, Parallel, TryAll, TryInOrder, Monitor, Code
 from pycram.process_module import simulated_robot
@@ -114,6 +115,80 @@ class LanguageTestCase(BulletWorldTestCase):
             return True
 
         self.assertRaises(AttributeError, lambda: Monitor(monitor_func) >> Monitor(monitor_func))
+
+    def test_retry_monitor_construction(self):
+        act = ParkArmsAction([Arms.BOTH])
+        act2 = MoveTorsoAction([0.3])
+
+        def monitor_func():
+            time.sleep(1)
+            return True
+
+        def recovery1():
+            return
+
+        recover1 = Code(lambda: recovery1())
+        recovery = {NotALanguageExpression: recover1}
+
+        subplan = act + act2 >> Monitor(monitor_func)
+        plan = RetryMonitor(subplan, max_tries=6, recovery=recovery)
+        self.assertEqual(len(plan.recovery), 1)
+        self.assertIsInstance(plan.designator_description, Monitor)
+
+    def test_retry_monitor_tries(self):
+        act = ParkArmsAction([Arms.BOTH])
+        act2 = MoveTorsoAction([0.3])
+        tries_counter = 0
+
+        def monitor_func():
+            nonlocal tries_counter
+            tries_counter += 1
+            return True
+
+        subplan = act + act2 >> Monitor(monitor_func)
+        plan = RetryMonitor(subplan, max_tries=6)
+        try:
+            plan.perform()
+        except PlanFailure as e:
+            pass
+        self.assertEqual(tries_counter, 6)
+
+    def test_retry_monitor_recovery(self):
+        recovery1_counter = 0
+        recovery2_counter = 0
+
+        def monitor_func():
+            if not hasattr(monitor_func, 'tries_counter'):
+                monitor_func.tries_counter = 0
+            if monitor_func.tries_counter % 2:
+                monitor_func.tries_counter += 1
+                return NotALanguageExpression
+            monitor_func.tries_counter += 1
+            return PlanFailure
+
+        def recovery1():
+            nonlocal recovery1_counter
+            recovery1_counter += 1
+
+        def recovery2():
+            nonlocal recovery2_counter
+            recovery2_counter += 1
+
+        recover1 = Code(lambda: recovery1())
+        recover2 = Code(lambda: recovery2())
+        recovery = {NotALanguageExpression: recover1,
+                    PlanFailure: recover2}
+
+        act = ParkArmsAction([Arms.BOTH])
+        act2 = MoveTorsoAction([0.3])
+        subplan = act + act2 >> Monitor(monitor_func)
+        plan = RetryMonitor(subplan, max_tries=6, recovery=recovery)
+        try:
+            plan.perform()
+        except PlanFailure as e:
+            pass
+        self.assertEqual(recovery1_counter, 2)
+        self.assertEqual(recovery2_counter, 3)
 
     def test_repeat_construction(self):
         act = ParkArmsAction([Arms.BOTH])

--- a/test/test_language.py
+++ b/test/test_language.py
@@ -271,7 +271,7 @@ class LanguageTestCase(BulletWorldTestCase):
 
         plan = act + code
         with simulated_robot:
-            state = plan.perform()
+            state, _ = plan.perform()
         self.assertIsInstance(plan.exceptions[plan], PlanFailure)
         self.assertEqual(len(plan.exceptions.keys()), 1)
         self.assertEqual(state, State.FAILED)
@@ -284,7 +284,7 @@ class LanguageTestCase(BulletWorldTestCase):
 
         plan = act - code
         with simulated_robot:
-            state = plan.perform()
+            state, _ = plan.perform()
         self.assertIsInstance(plan.exceptions[plan], list)
         self.assertIsInstance(plan.exceptions[plan][0], PlanFailure)
         self.assertEqual(len(plan.exceptions.keys()), 1)
@@ -298,7 +298,7 @@ class LanguageTestCase(BulletWorldTestCase):
 
         plan = act | code
         with simulated_robot:
-            state = plan.perform()
+            state, _ = plan.perform()
         self.assertIsInstance(plan.exceptions[plan], list)
         self.assertIsInstance(plan.exceptions[plan][0], PlanFailure)
         self.assertEqual(len(plan.exceptions.keys()), 1)
@@ -312,7 +312,7 @@ class LanguageTestCase(BulletWorldTestCase):
 
         plan = act ^ code
         with simulated_robot:
-            state = plan.perform()
+            state, _ = plan.perform()
         self.assertIsInstance(plan.exceptions[plan], list)
         self.assertIsInstance(plan.exceptions[plan][0], PlanFailure)
         self.assertEqual(len(plan.exceptions.keys()), 1)


### PR DESCRIPTION
Introduces the RetryMonitor class, a subclass of FailureHandling, which implements a retry mechanism specifically designed to work with a Monitor. This class aims to improve the robustness of task execution by allowing retries in case the monitoring condition is triggered.

