### PR TITLE
[SemanticCostmap] applied margin

### DIFF
--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -812,7 +812,7 @@ class SemanticCostmap(Costmap):
             self.map = self.map[:, max(0, non_zero_cols[0] - left_trim):non_zero_cols[-1] + 1 + right_trim]
 
 
-def get_aabb_for_link(self) -> AxisAlignedBoundingBox:
+    def get_aabb_for_link(self) -> AxisAlignedBoundingBox:
         """
         Returns the axis aligned bounding box (AABB) of the link provided when creating this costmap. To try and let the
         AABB as close to the actual object as possible, the Object will be rotated such that the link will be in the

--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -773,7 +773,7 @@ class SemanticCostmap(Costmap):
         self.width: int = 0
         self.map: np.ndarray = []
         self.generate_map()
-        self.margin_cm = margin_cm
+        self.margin_cm: float = margin_cm
         Costmap.__init__(self, resolution, self.height, self.width, self.origin, self.map)
 
     def generate_map(self) -> None:

--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -781,7 +781,7 @@ class SemanticCostmap(Costmap):
         Generates the semantic costmap according to the provided parameters. To do this the axis aligned bounding box (AABB)
         for the link name will be used. Height and width of the final Costmap will be the x and y sizes of the AABB.
         """
-        aabb_min, aabb_max = self.get_aabb_for_link()  # Get the axis-aligned bounding box for the link
+        aabb_min, aabb_max = self.get_aabb_for_link().get_min_max()   # Get the axis-aligned bounding box for the link
         margin = int(self.margin_cm / self.resolution)  # Convert 20 cm margin to pixels based on the resolution
 
         # Calculate height and width considering the resolution


### PR DESCRIPTION
I use this Costmap to generate placement poses for my complete pick-and-place demo on the real robot. The outer edges are reduced because the robot requires some clearance, especially when dealing with structures like shelves where the outer areas might be restricted. Since the standard semantic costmap is no longer in use, perhaps we should consider renaming this to something like placeSemanticCostmap, @Tigul. In the attached image, you can see an example for a countertop. Please note that I work with TF frames oriented according to the direction we agreed upon within the Suturo project.
![Screenshot from 2024-08-13 12-17-33](https://github.com/user-attachments/assets/e5746151-bf7c-409b-9f6e-eb8d7117b707)
