### PR TITLE
Ontology to pycram objects

### DIFF
--- a/src/pycram/ontology/ontology.py
+++ b/src/pycram/ontology/ontology.py
@@ -28,7 +28,7 @@ from enum import Enum
 
 # TODO: assumes SOMA_DFL, and specifically a "module" resulting from selecting some of its concepts,
 # is the default main ontology.
-SOMA_DFL_ONTOLOGY_IRI = "http://www.ease-crc.org/ont/SOMA_DFL_module.owl"
+SOMA_DFL_ONTOLOGY_IRI = "https://raw.githubusercontent.com/ease-crc/ease_lexical_resources/master/src/dfl/owl/SOMA_DFL_module_merged.owl"
 SOMA_HOME_ONTOLOGY_IRI = "http://www.ease-crc.org/ont/SOMA-HOME.owl"
 SOMA_ONTOLOGY_IRI = "http://www.ease-crc.org/ont/SOMA.owl"
 SOMA_ONTOLOGY_NAMESPACE = "SOMA"

--- a/src/pycram/ontology/ontology.py
+++ b/src/pycram/ontology/ontology.py
@@ -882,11 +882,8 @@ class OntologyManager(object, metaclass=Singleton):
         For example, "dul:Object" becomes "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object".
         
         :param conceptName: a string containing a possibly shortened concept name
-        :type conceptName: str
         :param namespaceMap: a dictionary of namespace names mapped to IRI prefixes. If left None, the default namespace map of the ontology manager object is used. It is often a good idea to just use the default map.
-        :type namespaceMap: dict, optional
         :return conceptIRI: an IRI string. If the input conceptName is already an IRI form, conceptIRI = conceptName.
-        :type conceptIRI: str
         """
         if namespaceMap is None:
             namespaceMap = self.namespaceMap
@@ -911,15 +908,10 @@ class OntologyManager(object, metaclass=Singleton):
         
         :param concept: an OWLReady2 class, a string, or an enum with values strings or OWLReady2 classes. 
                      If a string (or string-valued enum), can be an IRI or short name.
-        :type concept: owlready2.entity.ThingClass, str, or enum
         :param concept2Enum: a dictionary mapping concept IRIs to pycram object types. Can be often left to None, in which case the default mapping defined in the ontology manager is used.        
-        :type concept2Enum: dict, optional
         :param iri2Concept: a mapping from IRIs to OWLReady2 classes. Can and should be left None, in which case the mapping maintained by the ontology mapper is used.
-        :type iri2Concept: dict, optional
         :param namespaceMap: a mapping of namespace names to IRI prefixes. Can be left None, in which case the default mapping definedin the ontology manager is used.
-        :type namespaceMap: dict, optional
         :return objectTypes: a list of pycram object types that are subconcepts of the input concept.
-        :type objectTypes: list
         """
         if iri2Concept is None:
             iri2Concept = self.iri2Concept

--- a/src/pycram/ontology/ontology.py
+++ b/src/pycram/ontology/ontology.py
@@ -880,11 +880,12 @@ class OntologyManager(object, metaclass=Singleton):
         A function to convert a concept name -- which may be shortened by using a namespace prefix -- into an IRI.
         For example, "dul:Object" becomes "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object".
         
-        Inputs:
-            conceptName: a string containing a possibly shortened concept name
-            namespaceMap: a dictionary of namespace names mapped to IRI prefixes. If left None, the default namespace map of the ontology manager object is used. It is often a good idea to just use the default map.
-        Returns:
-            conceptIRI: an IRI string. If the input conceptName is already an IRI form, conceptIRI = conceptName.
+        :param conceptName: a string containing a possibly shortened concept name
+        :type conceptName: str
+        :param namespaceMap: a dictionary of namespace names mapped to IRI prefixes. If left None, the default namespace map of the ontology manager object is used. It is often a good idea to just use the default map.
+        :type namespaceMap: dict, optional
+        :return conceptIRI: an IRI string. If the input conceptName is already an IRI form, conceptIRI = conceptName.
+        :type conceptIRI: str
         """
         if namespaceMap is None:
             namespaceMap = self.namespaceMap
@@ -905,14 +906,17 @@ class OntologyManager(object, metaclass=Singleton):
         Not all subconcepts of the given concept may have pycram equivalents. Such unmapped subconcepts are ignored and not
         represented in the output in any way.
         
-        Inputs:
-            concept: an OWLReady2 class, a string, or an enum with values strings or OWLReady2 classes. 
+        :param concept: an OWLReady2 class, a string, or an enum with values strings or OWLReady2 classes. 
                      If a string (or string-valued enum), can be an IRI or short name.
-            concept2Enum: a dictionary mapping concept IRIs to pycram object types. Can be often left to None, in which case the default mapping defined in the ontology manager is used.
-            iri2Concept: a mapping from IRIs to OWLReady2 classes. Can and should be left None, in which case the mapping maintained by the ontology mapper is used.
-            namespaceMap: a mapping of namespace names to IRI prefixes. Can be left None, in which case the default mapping definedin the ontology manager is used.
-        Returns:
-            objectTypes: a list of pycram object types that are subconcepts of the input concept.
+        :type concept: owlready2.entity.ThingClass, str, or enum
+        :param concept2Enum: a dictionary mapping concept IRIs to pycram object types. Can be often left to None, in which case the default mapping defined in the ontology manager is used.        
+        :type concept2Enum: dict, optional
+        :param iri2Concept: a mapping from IRIs to OWLReady2 classes. Can and should be left None, in which case the mapping maintained by the ontology mapper is used.
+        :type iri2Concept: dict, optional
+        :param namespaceMap: a mapping of namespace names to IRI prefixes. Can be left None, in which case the default mapping definedin the ontology manager is used.
+        :type namespaceMap: dict, optional
+        :return objectTypes: a list of pycram object types that are subconcepts of the input concept.
+        :type objectTypes: list
         """
         if iri2Concept is None:
             iri2Concept = self.iri2Concept

--- a/src/pycram/ontology/ontology.py
+++ b/src/pycram/ontology/ontology.py
@@ -68,22 +68,23 @@ class OntologyManager(object, metaclass=Singleton):
                     "": "http://www.ease-crc.org/ont/SOMA_DFL.owl#",
                     "home": "http://www.ease-crc.org/ont/SOMA-HOME.owl",
                     "dul": "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#",
+                    "USD": "https://ease-crc.org/ont/USD.owl#",
                     "soma": "http://www.ease-crc.org/ont/SOMA.owl#"
     }
 
     # Dirty hack to map concept IRIs to pycram object types
     iri2PyCramObjectType = {
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#mug.n.wn.artifact": METALMUG,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#can_of_chips.n.wn.artifact": PRINGLES,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#milk_carton.n.wn.artifact": MILK,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#spoon.n.wn.artifact..cutlery": SPOON,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#bowl.n.wn.artifact..dish": BOWL,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#cereal_box.n.wn.artifact": BREAKFAST_CEREAL,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#cup.n.wn.artifact..container": JEROEN_CUP,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#mug.n.wn.artifact": ObjectType.METALMUG,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#can_of_chips.n.wn.artifact": ObjectType.PRINGLES,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#milk_carton.n.wn.artifact": ObjectType.MILK,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#spoon.n.wn.artifact..cutlery": ObjectType.SPOON,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#bowl.n.wn.artifact..dish": ObjectType.BOWL,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#cereal_box.n.wn.artifact": ObjectType.BREAKFAST_CEREAL,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#cup.n.wn.artifact..container": ObjectType.JEROEN_CUP,
         #"": ROBOT,
         #"": ENVIRONMENT,
-        "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#DesignedArtifact": GENERIC_OBJECT,
-        "http://www.ease-crc.org/ont/SOMA_DFL.owl#person.n.wn.body": HUMAN
+        "http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#DesignedArtifact": ObjectType.GENERIC_OBJECT,
+        "http://www.ease-crc.org/ont/SOMA_DFL.owl#person.n.wn.body": ObjectType.HUMAN
     }
 
     def __init__(self, main_ontology_iri: Optional[str] = None, ontology_search_path: Optional[str] = None,
@@ -892,6 +893,8 @@ class OntologyManager(object, metaclass=Singleton):
         conceptIRI = conceptName
         # ':' must occur exactly once in an IRI or short concept name.
         idx = conceptName.find(':')
+        if -1 == idx:
+            raise ValueError('Concept name is neither a valid IRI nor a valid short name: the namespace seems missing.')
         # "//" after a ":" indicates a protocol has been specified to the left of the ":", i.e. we have an IRI already.
         recStr = "//"        
         if recStr != conceptName[idx+1:idx+len(recStr)+1]
@@ -925,7 +928,7 @@ class OntologyManager(object, metaclass=Singleton):
         if isinstance(concept, Enum):
             concept = concept.value
         if isinstance(concept, str):
-            concept = iri2Concept[self.string2IRI(self.ensure_concept_name_is_IRI(concept, namespaceMap=namespaceMap))]
+            concept = iri2Concept[self.ensure_concept_name_is_IRI(concept, namespaceMap=namespaceMap)]
         subconcepts = set()
         todo = set([concept])
         while todo:

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -71,7 +71,6 @@ class TestOntologyManager(unittest.TestCase):
         if os.path.exists(sql_journal_filepath):
             os.remove(sql_journal_filepath)
 
-    @unittest.skipUnless(True, 'never skip')
     def test_ontology_manager(self):
         # This works because OntologyManager is a singleton.
         self.assertIs(self.ontology_manager, OntologyManager())
@@ -308,7 +307,6 @@ class TestOntologyManager(unittest.TestCase):
         self.assertTrue(Path(owl_filepath).is_file())
         self.assertTrue(Path(sql_filepath).is_file())
     
-    @unittest.skipUnless(True, 'Never skip')
     def test_ensure_concept_name_is_IRI(self):
         defaultNamespaceMap = None
         variantNamespaceMap = {"owl": "http://ornithology.org/birds/OWL#", "xyz": "http://nowhere.org/nothing#"}


### PR DESCRIPTION
Work in progress, but started a pull request to draw attention to this.

TODOs:

1. SERIOUS: get SOMA_DFL and/or SOMA_DFL_module online so the onto loader can get to them without needing to depend on the dfl python package. Currently, these would be accessible only on a github tree.
2. Serious: test to remove silly typos
3. Good to have (but not threatening to functionality, at least in limited use cases): Integration with rest of onto manager. E.g., I prefer to have an iri2Concept map to switch between string names and the actual OWLReady2 generated classes. What other functions in the onto manager may impact this mapping?
4. Good to have (eventually): query complex concept expressions. This will require integrating a different reasoner in there (Konclude) or only use modules of SOMA_DFL so that OWLReady2's HermiT doesn't die.
5. Good to have (eventually): a more elegant map between pycram object types and ontology classes.