### PR TITLE
Fix missing import and error in tf_broadcaster

### DIFF
--- a/src/pycram/ros/tf_broadcaster.py
+++ b/src/pycram/ros/tf_broadcaster.py
@@ -5,6 +5,7 @@ import atexit
 
 from ..datastructures.pose import Pose
 from ..datastructures.world import World
+from ..datastructures.enums import ExecutionType
 from tf2_msgs.msg import TFMessage
 
 
@@ -12,7 +13,7 @@ class TFBroadcaster:
     """
     Broadcaster that publishes TF frames for every object in the World.
     """
-    def __init__(self, projection_namespace= ExecutionType.SIMULATED, odom_frame="odom", interval=0.1):
+    def __init__(self, projection_namespace=ExecutionType.SIMULATED, odom_frame="odom", interval=0.1):
         """
         The broadcaster prefixes all published TF messages with a projection namespace to distinguish between the TF
         frames from the simulation and the one from the real robot.
@@ -78,8 +79,8 @@ class TFBroadcaster:
         frame_id = pose.frame
         if frame_id != child_frame_id:
             tf_stamped = pose.to_transform(child_frame_id)
-            tf_stamped.frame = self.projection_namespace + "/" + tf_stamped.frame
-            tf_stamped.child_frame_id = self.projection_namespace + "/" + tf_stamped.child_frame_id
+            tf_stamped.frame = self.projection_namespace.name + "/" + tf_stamped.frame
+            tf_stamped.child_frame_id = self.projection_namespace.name + "/" + tf_stamped.child_frame_id
             tf2_msg = TFMessage()
             tf2_msg.transforms.append(tf_stamped)
             if static:


### PR DESCRIPTION
Ran into an error here. Since the property projection_namespace is now of type ExecutionType it cannot be concatenated with a string anymore. So we can take the name for that.