### PR TITLE
Find non-fixed parent joint for link.

### DIFF
--- a/src/pycram/designators/location_designator.py
+++ b/src/pycram/designators/location_designator.py
@@ -327,8 +327,8 @@ class AccessingLocation(LocationDesignatorDescription):
         :yield: A location designator containing the pose and the arms that can be used.
         """
 
-        # Find a Joint of type prismatic which is above the handle in the URDF tree
-        container_joint = self.handle.world_object.find_joint_above_link(self.handle.name, JointType.PRISMATIC)
+        # Find a Joint that moves with the handle in the URDF tree
+        container_joint = self.handle.world_object.find_joint_above_link(self.handle.name)
 
         init_pose = link_pose_for_joint_config(self.handle.world_object, {
             container_joint: self.handle.world_object.get_joint_limits(container_joint)[0]},

--- a/src/pycram/world_concepts/world_object.py
+++ b/src/pycram/world_concepts/world_object.py
@@ -1268,23 +1268,22 @@ class Object(WorldEntity, HasConcept):
         """
         return self.joints[joint_name].parent_link
 
-    def find_joint_above_link(self, link_name: str, joint_type: JointType) -> str:
+    def find_joint_above_link(self, link_name: str) -> str:
         """
-        Traverse the chain from 'link' to the URDF origin and return the first joint that is of type 'joint_type'.
+        Traverse the chain from 'link' to the URDF origin and return the first joint that is not FIXED.
 
         :param link_name: AbstractLink name above which the joint should be found
-        :param joint_type: Joint type that should be searched for
-        :return: Name of the first joint which has the given type
+        :return: Name of the first non-fixed joint, None if no joint is found
         """
         chain = self.description.get_chain(self.description.get_root(), link_name)
         reversed_chain = reversed(chain)
         container_joint = None
         for element in reversed_chain:
-            if element in self.joint_name_to_id and self.get_joint_type(element) == joint_type:
+            if element in self.joint_name_to_id and self.get_joint_type(element) != JointType.FIXED:
                 container_joint = element
                 break
         if not container_joint:
-            logwarn(f"No joint of type {joint_type} found above link {link_name}")
+            logwarn(f"No movable parent joint found above link {link_name}")
         return container_joint
 
     def get_multiple_joint_positions(self, joint_names: List[str]) -> Dict[str, float]:

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -138,11 +138,10 @@ class TestObject(BulletWorldTestCase):
         self.assertEqual(self.robot.get_link_by_id(-1), self.robot.root_link)
 
     def test_find_joint_above_link(self):
-        self.assertEqual(self.robot.find_joint_above_link("head_pan_link", JointType.REVOLUTE), "head_pan_joint")
+        self.assertEqual(self.robot.find_joint_above_link("head_pan_link"), "head_pan_joint")
 
-    def test_wrong_joint_type_for_joint_above_link(self):
-        container_joint = self.robot.find_joint_above_link("head_pan_link", JointType.CONTINUOUS)
-        self.assertTrue(container_joint is None)
+    def test_find_joint_above_link_exhausted(self):
+        self.assertEqual(self.robot.find_joint_above_link("base_link"), None)
 
     def test_contact_points_simulated(self):
         self.milk.set_position([0, 0, 100])


### PR DESCRIPTION
This removes the joint type when searching for the movable parent joint of a link, e.g. a handle, finding the closest non-fixed joint.

I also adjusted the tests and all occurrences.

@AbdelrhmanBassiouny could you have a look?