### PR TITLE
Add grasps BOTTOM and BACK

### DIFF
--- a/src/pycram/datastructures/enums.py
+++ b/src/pycram/datastructures/enums.py
@@ -51,6 +51,8 @@ class Grasp(int, Enum):
     LEFT = 1
     RIGHT = 2
     TOP = 3
+    BACK = 4
+    BOTTOM = 5
 
 
 class ObjectType(int, Enum):

--- a/src/pycram/robot_descriptions/pr2_description.py
+++ b/src/pycram/robot_descriptions/pr2_description.py
@@ -3,8 +3,6 @@ from ..robot_description import RobotDescription, KinematicChainDescription, End
     RobotDescriptionManager, CameraDescription
 from ..datastructures.enums import Arms, Grasp, GripperState, GripperType, TorsoState
 from ..ros.ros_tools import get_ros_package_path
-from tf.transformations import quaternion_from_euler
-import numpy as np
 
 from ..helper import get_robot_mjcf_path
 
@@ -88,12 +86,12 @@ pr2_description.add_kinematic_chain_description(torso)
 pr2_description.add_kinematic_chain("neck", "head_pan_link", "head_tilt_link")
 
 ################################# Grasps ##################################
-pr2_description.add_grasp_orientations({Grasp.FRONT: list(quaternion_from_euler(0, 0, 0)),
-                                        Grasp.BACK: list(quaternion_from_euler(0, 0, np.pi)),
-                                        Grasp.LEFT: list(quaternion_from_euler(0, 0, -np.pi/2)),
-                                        Grasp.RIGHT: list(quaternion_from_euler(0, 0, np.pi/2)),
-                                        Grasp.TOP: list(quaternion_from_euler(0, np.pi/2, 0)),
-                                        Grasp.BOTTOM: list(quaternion_from_euler(0, -np.pi/2, 0))})
+pr2_description.add_grasp_orientations({Grasp.FRONT:    [0.0, 0.0, 0.0, 1.0],
+                                        Grasp.BACK:     [0.0, 0.0, 1.0, 0.0],
+                                        Grasp.LEFT:     [0.0, 0.0, -0.7071067811865475, 0.7071067811865476],
+                                        Grasp.RIGHT:    [0.0, 0.0, 0.7071067811865475, 0.7071067811865476],
+                                        Grasp.TOP:      [0.0, 0.7071067811865475, 0.0, 0.7071067811865476],
+                                        Grasp.BOTTOM:   [0.0, -0.7071067811865475, 0.0, 0.7071067811865476]})
 
 # Add to RobotDescriptionManager
 rdm = RobotDescriptionManager()

--- a/src/pycram/robot_descriptions/pr2_description.py
+++ b/src/pycram/robot_descriptions/pr2_description.py
@@ -3,6 +3,8 @@ from ..robot_description import RobotDescription, KinematicChainDescription, End
     RobotDescriptionManager, CameraDescription
 from ..datastructures.enums import Arms, Grasp, GripperState, GripperType, TorsoState
 from ..ros.ros_tools import get_ros_package_path
+from tf.transformations import quaternion_from_euler
+import numpy as np
 
 from ..helper import get_robot_mjcf_path
 
@@ -86,10 +88,12 @@ pr2_description.add_kinematic_chain_description(torso)
 pr2_description.add_kinematic_chain("neck", "head_pan_link", "head_tilt_link")
 
 ################################# Grasps ##################################
-pr2_description.add_grasp_orientations({Grasp.FRONT: [0, 0, 0, 1],
-                                        Grasp.LEFT: [0, 0, -1, 1],
-                                        Grasp.RIGHT: [0, 0, 1, 1],
-                                        Grasp.TOP: [0, 1, 0, 1]})
+pr2_description.add_grasp_orientations({Grasp.FRONT: list(quaternion_from_euler(0, 0, 0)),
+                                        Grasp.BACK: list(quaternion_from_euler(0, 0, np.pi)),
+                                        Grasp.LEFT: list(quaternion_from_euler(0, 0, -np.pi/2)),
+                                        Grasp.RIGHT: list(quaternion_from_euler(0, 0, np.pi/2)),
+                                        Grasp.TOP: list(quaternion_from_euler(0, np.pi/2, 0)),
+                                        Grasp.BOTTOM: list(quaternion_from_euler(0, -np.pi/2, 0))})
 
 # Add to RobotDescriptionManager
 rdm = RobotDescriptionManager()

--- a/test/test_designator/test_move_and_pick_up.py
+++ b/test/test_designator/test_move_and_pick_up.py
@@ -28,7 +28,7 @@ class MoveAndPickUpTestCase(BulletWorldTestCase):
     def test_variables(self):
         object_designator = ObjectDesignatorDescription(types=[Milk]).resolve()
         move_and_pick = MoveAndPickUp(object_designator, arms=[Arms.LEFT, Arms.RIGHT],
-                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP])
+                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP, Grasp.BOTTOM, Grasp.BACK])
         result = SortedSet([Symbolic("arm", PMArms), Symbolic("grasp", PMGrasp),
                             Continuous("relative_x"), Continuous("relative_y")])
         all_variables = move_and_pick.all_variables()
@@ -37,7 +37,7 @@ class MoveAndPickUpTestCase(BulletWorldTestCase):
     def test_grounding(self):
         object_designator = ObjectDesignatorDescription(types=[Milk]).resolve()
         move_and_pick = MoveAndPickUp(object_designator, arms=[Arms.LEFT, Arms.RIGHT],
-                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP])
+                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP, Grasp.BOTTOM, Grasp.BACK])
 
         model = move_and_pick.ground_model()
         event = move_and_pick.events_from_occupancy_and_visibility_costmap()
@@ -47,7 +47,7 @@ class MoveAndPickUpTestCase(BulletWorldTestCase):
     def test_move_and_pick_up_with_mode(self):
         object_designator = ObjectDesignatorDescription(types=[Milk]).resolve()
         move_and_pick = MoveAndPickUp(object_designator, arms=[Arms.LEFT, Arms.RIGHT],
-                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP])
+                                      grasps=[Grasp.FRONT, Grasp.LEFT, Grasp.RIGHT, Grasp.TOP, Grasp.BOTTOM, Grasp.BACK])
         with simulated_robot:
             for action in move_and_pick.iter_with_mode():
                 try:


### PR DESCRIPTION
Adds the BACK and BOTTOM grasp to the dataclass and PR2 description. Necessary for picking objects out of the fridge that are spawned with default rotation.

Also uses the normalized quaternions.