### PR TITLE
[PyCrap] define joint ontology in joint class, HasConcept is in WorldEntity

### DIFF
--- a/src/pycram/datastructures/world.py
+++ b/src/pycram/datastructures/world.py
@@ -12,7 +12,7 @@ from geometry_msgs.msg import Point
 from trimesh.parent import Geometry3D
 from typing_extensions import List, Optional, Dict, Tuple, Callable, TYPE_CHECKING, Union, Type, deprecated
 
-
+import pycrap
 from pycrap.ontologies import PhysicalObject
 from pycrap.ontology_wrapper import OntologyWrapper
 
@@ -93,9 +93,10 @@ class World(WorldEntity, ABC):
         :param clear_cache: Whether to clear the cache directory.
         :param id_: The unique id of the world.
         """
-
-        WorldEntity.__init__(self, id_, self)
         self.ontology = OntologyWrapper()
+        self.is_prospection_world: bool = is_prospection
+        WorldEntity.__init__(self, id_, self, concept=pycrap.ontologies.World)
+
         self.latest_state_id: Optional[int] = None
 
         if clear_cache or (self.conf.clear_cache_at_start and not self.cache_manager.cache_cleared):
@@ -113,7 +114,6 @@ class World(WorldEntity, ABC):
         self.objects: List[Object] = []
         # List of all Objects in the World
 
-        self.is_prospection_world: bool = is_prospection
         self._init_and_sync_prospection_world()
 
         self.local_transformer = LocalTransformer()

--- a/src/pycram/datastructures/world_entity.py
+++ b/src/pycram/datastructures/world_entity.py
@@ -118,15 +118,16 @@ class StateEntity:
         self._saved_states = {}
 
 
-class WorldEntity(StateEntity, ABC):
+class WorldEntity(StateEntity, HasConcept, ABC):
     """
     A class that represents an entity of the world, such as an object or a link.
     """
 
-    def __init__(self, _id: int, world: World):
+    def __init__(self, _id: int, world: World, concept: Type[PhysicalObject] = PhysicalObject, parse_name: bool = True):
         StateEntity.__init__(self)
         self.id = _id
         self.world: World = world
+        HasConcept.__init__(self, name=self.name, world=self.world, concept=concept, parse_name=parse_name)
 
     @property
     @abstractmethod
@@ -156,7 +157,7 @@ class WorldEntity(StateEntity, ABC):
         return hash((self.id, self.name, self.parent_entity))
 
 
-class PhysicalBody(WorldEntity, HasConcept, ABC):
+class PhysicalBody(WorldEntity, ABC):
     """
     A class that represents a physical body in the world that has some related physical properties.
     """
@@ -168,8 +169,7 @@ class PhysicalBody(WorldEntity, HasConcept, ABC):
 
     def __init__(self, body_id: int, world: World, concept: Type[PhysicalObject] = PhysicalObject,
                  parse_name: bool = True):
-        WorldEntity.__init__(self, body_id, world)
-        HasConcept.__init__(self, name=self.name, world=self.world, concept=concept, parse_name=parse_name)
+        WorldEntity.__init__(self, body_id, world, concept, parse_name)
 
         self.local_transformer = LocalTransformer()
         self._is_translating: Optional[bool] = None

--- a/src/pycram/description.py
+++ b/src/pycram/description.py
@@ -12,7 +12,7 @@ from typing_extensions import Tuple, Union, Any, List, Optional, Dict, TYPE_CHEC
 
 import pycrap
 import pycrap.ontologies
-from pycrap.ontologies import Base
+from pycrap.ontologies import Base, has_child_link, has_parent_link
 from .datastructures.dataclasses import JointState, AxisAlignedBoundingBox, Color, LinkState, VisualShape, \
     MeshVisualShape, RotatedBoundingBox
 from .datastructures.enums import JointType
@@ -512,14 +512,28 @@ class Joint(WorldEntity, ObjectEntity, JointDescription, ABC):
 
     def __init__(self, _id: int,
                  joint_description: JointDescription,
-                 obj: Object, is_virtual: Optional[bool] = False):
-        WorldEntity.__init__(self, _id, obj.world)
+                 obj: Object, is_virtual: Optional[bool] = False,
+                 concept: Type[Base] = pycrap.ontologies.Joint):
+        self.description = joint_description
+        WorldEntity.__init__(self, _id, obj.world, concept=concept, parse_name=False)
         ObjectEntity.__init__(self, obj)
         JointDescription.__init__(self, joint_description.parsed_description, is_virtual)
-        self.description = joint_description
+
         self.acceptable_error = (self.world.conf.revolute_joint_position_tolerance if self.type == JointType.REVOLUTE
                                  else self.world.conf.prismatic_joint_position_tolerance)
         self._update_position()
+        self._update_ontology_data()
+
+    def _update_ontology_data(self):
+        """
+        Update the ontology data of this joint and its parent and child links.
+        """
+        if self.world.is_prospection_world:
+            return
+        self.ontology_individual.is_a = [has_child_link.some(self.child_link.ontology_individual)]
+        if self.parent_link.ontology_individual:
+            self.ontology_individual.is_a = [has_parent_link.some(self.parent_link.ontology_individual)]
+            self.child_link.ontology_individual.is_part_of = [self.parent_link.ontology_individual]
 
     @property
     def name(self) -> str:

--- a/src/pycram/world_concepts/world_object.py
+++ b/src/pycram/world_concepts/world_object.py
@@ -467,19 +467,8 @@ class Object(PhysicalBody):
         for joint_name, joint_id in self.joint_name_to_id.items():
             parsed_joint_description = self.description.get_joint_by_name(joint_name)
             is_virtual = self.is_joint_virtual(joint_name)
-            self.joints[joint_name] = self.description.Joint(joint_id, parsed_joint_description, self, is_virtual)
-            if not self.world.is_prospection_world:
-                individual = self.ontology_concept(joint_name, namespace=self.world.ontology.ontology)
-                self.world.ontology.python_objects[individual] = parsed_joint_description
-                individual.is_a = [self.ontology_concept, has_child_link.some(
-                    self.get_joint_child_link(joint_name).ontology_individual),
-                                   has_parent_link.some(
-                                       self.get_joint_child_link(joint_name).ontology_individual)]
-                link_individual = self.get_joint_child_link(joint_name).ontology_individual
-
-                if self.get_joint_parent_link(joint_name).ontology_individual:
-                    link_individual.is_part_of = [
-                        self.get_joint_parent_link(joint_name).ontology_individual]
+            self.joints[joint_name] = self.description.Joint(joint_id, parsed_joint_description, self,
+                                                             is_virtual=is_virtual)
 
     def is_joint_virtual(self, name: str):
         """

--- a/src/pycrap/ontologies/crax/classes.py
+++ b/src/pycrap/ontologies/crax/classes.py
@@ -1,89 +1,121 @@
 from .dependencies import *
 
+
+class World(Base):
+    """
+    The world could be the belief state of an agent about the world.
+    """
+
+
 class Floor(Base):
     """
     The floor of the world.
     """
+
 
 class Milk(Base):
     """
     A milk carton.
     """
 
+
 class Robot(Base):
     """
     The robot.
     """
+
 
 class Cereal(Base):
     """
     A cereal box.
     """
 
+
 class Kitchen(Base):
     """
     A kitchen.
     """
 
+
 class Food(Base):
     ...
+
 
 class Apartment(Base):
     ...
 
+
 class Cup(Base):
     ...
+
 
 class Spoon(Base):
     ...
 
+
 class Bowl(Base):
     ...
+
 
 class Cabinet(Base):
     ...
 
+
 class Washer(Base):
     ...
+
 
 class Drawer(Base):
     ...
 
+
 class Refrigerator(Base):
     ...
+
 
 class Sink(Base):
     ...
 
+
 class Door(Base):
     ...
+
 
 class Cutting(Base):
     ...
 
+
 class Pouring(Base):
     ...
+
 
 class Handle(Base):
     ...
 
+
 class Link(Base):
     ...
+
 
 class PhysicalObject(Base):
     ...
 
+
 class Agent(Base):
     ...
+
 
 class Room(Base):
     ...
 
+
 class Location(Base):
     ...
 
+
 class Container(Base):
     ...
+
 
 class Joint(Base):
     ...
@@ -112,40 +144,48 @@ class MovableJoint(Base):
     A joint where the two connected links can move relative to each other in some dimension.
     """
 
+
 class FloatingJoint(Base):
     """
     A joint that allows motion for all 6 degrees of freedom.
     """
+
 
 class PlanarJoint(Base):
     """
     A joint that allows motion in a plane perpendicular to an axis.
     """
 
+
 class PrismaticJoint(Base):
     """
     A sliding joint that slides along an axis, and has a limited range specified by the upper and lower limits.
     """
+
 
 class RevoluteJoint(Base):
     """
     A hinge joint that rotates along an axis and has a limited range specified by the upper and lower limits.
     """
 
+
 class DesignedFurniture(Base):
     """
     An object used to make a room or building suitable for living or working.
     """
+
 
 class Surface(Base):
     """
     The outside part or uppermost layer of something.
     """
 
+
 class PhysicalTask(Base):
     """
     A task in which a PhysicalAgent affects some physical object.
     """
+
 
 class Action(Base):
     """
@@ -191,10 +231,12 @@ class Event(Base):
     For this reason, in this ontology version of DOLCE, both events and situations are allowed, together with descriptions (the reason for the inclusion of the D&S framewrok in DOLCE), in order to encode the modelling needs, independently from the position (if any) chosen by the model designer.
     """
 
+
 class Entity(Base):
     """
     Anything: real, possible, or imaginary, which some modeller wants to talk about for some purpose.
     """
+
 
 class Task(Base):
     """
@@ -203,6 +245,7 @@ class Task(Base):
     The actions to execute a task can also be organized according to a Plan that is not the same as the one that defines the task (if any).
     For example, reaching a destination could be defined by a plan to get on holidays, while the plan to execute the task can consist of putting some travels into a sequence.
     """
+
 
 class RootLink(Base):
     ...


### PR DESCRIPTION
[PyCrap] moved update of joint ontology individual to Joint class, moved HasConcept from PhysicalBody to WorldEntity so as to make joints also have a concept as they inherit from WorldEntity not from PhysicalBody, it also makes sense as every thing in the world should theoretically have a concept.