### PR TITLE
New functions for Pose Stamped and tests

### DIFF
--- a/src/pycram/datastructures/pose.py
+++ b/src/pycram/datastructures/pose.py
@@ -619,18 +619,6 @@ class PoseStamped(HasParameters):
         result = {a: self.is_facing_2d_axis(pose_b, axis=a) for a in (AxisIdentifier.X, AxisIdentifier.Y)}
         return any(r[0] for r in result.values())
 
-    def get_rotation_offset_from_axis_preference(self, pose_b: PoseStamped) -> Tuple[int, float]:
-        """
-        Compute a discrete rotation offset (-90 or 90 degrees) to align this pose's local axes with the direction
-        toward a target pose, based on which axis (X or Y) is more aligned.
-
-        :param pose_b: The target pose to align with.
-        :return: Tuple of (rotation offset in degrees, signed angle difference in radians for Y axis).
-        """
-        fx, ax = self.is_facing_2d_axis(pose_b, axis=AxisIdentifier.X)
-        fy, ay = self.is_facing_2d_axis(pose_b, axis=AxisIdentifier.Y)
-
-        return (-90 if abs(ax) > abs(ay) else 90), ay
 
 
 @dataclass

--- a/src/pycram/datastructures/pose.py
+++ b/src/pycram/datastructures/pose.py
@@ -585,7 +585,9 @@ class PoseStamped(HasParameters):
         """
         self.orientation = self.orientation * Quaternion.from_list(quaternion)
 
-    def is_facing_2d_axis(self, pose_b, axis='x', threshold_deg=82):
+    def is_facing_2d_axis(self, pose_b: PoseStamped, axis: Optional[AxisIdentifier] = AxisIdentifier.X,
+                          threshold_deg=82) -> \
+            Tuple[bool, float]:
         """
          Check if this pose is facing another pose along a specific axis (X or Y) within a given angular threshold.
 
@@ -601,12 +603,12 @@ class PoseStamped(HasParameters):
 
         q = self.orientation
         yaw = math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y ** 2 + q.z ** 2))
-        if axis == 'y':
+        if axis == AxisIdentifier.Y:
             yaw += math.pi / 2
         diff = math.atan2(math.sin(target_angle - yaw), math.cos(target_angle - yaw))
         return abs(diff) < math.radians(threshold_deg), diff
 
-    def is_facing_x_or_y(self, pose_b):
+    def is_facing_x_or_y(self, pose_b: PoseStamped) -> bool:
         """
         Check if this pose is facing another pose along either the X or Y axis within a default angular threshold.
 
@@ -614,10 +616,10 @@ class PoseStamped(HasParameters):
         :return: True if this pose is facing the target along either X or Y axis, False otherwise.
         """
 
-        result = {a: self.is_facing_2d_axis(pose_b, axis=a) for a in ('x', 'y')}
+        result = {a: self.is_facing_2d_axis(pose_b, axis=a) for a in (AxisIdentifier.X, AxisIdentifier.Y)}
         return any(r[0] for r in result.values())
 
-    def get_rotation_offset_from_axis_preference(self, pose_b):
+    def get_rotation_offset_from_axis_preference(self, pose_b: PoseStamped) -> Tuple[int, float]:
         """
         Compute a discrete rotation offset (-90 or 90 degrees) to align this pose's local axes with the direction
         toward a target pose, based on which axis (X or Y) is more aligned.
@@ -625,12 +627,10 @@ class PoseStamped(HasParameters):
         :param pose_b: The target pose to align with.
         :return: Tuple of (rotation offset in degrees, signed angle difference in radians for Y axis).
         """
-        fx, ax = self.is_facing_2d_axis(pose_b, axis='x')
-        fy, ay = self.is_facing_2d_axis(pose_b, axis='y')
+        fx, ax = self.is_facing_2d_axis(pose_b, axis=AxisIdentifier.X)
+        fy, ay = self.is_facing_2d_axis(pose_b, axis=AxisIdentifier.Y)
 
         return (-90 if abs(ax) > abs(ay) else 90), ay
-
-
 
 
 @dataclass

--- a/src/pycram/datastructures/pose.py
+++ b/src/pycram/datastructures/pose.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import math
 from dataclasses import dataclass, field, fields
 
 import numpy as np
@@ -443,7 +444,9 @@ class PoseStamped(HasParameters):
         :param child_link_id: Frame to which the transform is pointing.
         :return: A TransformStamped object.
         """
-        return TransformStamped(header=self.header, pose=Transform.from_list(self.position.to_list(), self.orientation.to_list()), child_frame_id=child_link_id)
+        return TransformStamped(header=self.header,
+                                pose=Transform.from_list(self.position.to_list(), self.orientation.to_list()),
+                                child_frame_id=child_link_id)
 
     def round(self, decimals: int = 4):
         """
@@ -517,7 +520,7 @@ class PoseStamped(HasParameters):
         return primary_face, secondary_face
 
     def calculate_grasp_descriptions(self, robot: Object, grasp_alignment: Optional[PreferredGraspAlignment] = None) -> \
-    List[GraspDescription]:
+            List[GraspDescription]:
         """
         This method determines the possible grasp configurations (approach axis and vertical alignment) of the self,
         taking into account the self's orientation, position, and whether the gripper should be rotated by 90°.
@@ -581,6 +584,53 @@ class PoseStamped(HasParameters):
         :param quaternion: A list representing the quaternion [x, y, z, w].
         """
         self.orientation = self.orientation * Quaternion.from_list(quaternion)
+
+    def is_facing_2d_axis(self, pose_b, axis='x', threshold_deg=82):
+        """
+         Check if this pose is facing another pose along a specific axis (X or Y) within a given angular threshold.
+
+         :param pose_b: The target pose to compare against.
+         :param axis: The axis to check alignment with ('x' or 'y'). Defaults to 'x'.
+         :param threshold_deg: The maximum angular difference in degrees to consider as 'facing'. Defaults to 82 degrees.
+         :return: Tuple of (True/False if facing, signed angular difference in radians).
+         """
+
+        a_pos = np.array([self.position.x, self.position.y])
+        b_pos = np.array([pose_b.position.x, pose_b.position.y])
+        target_angle = math.atan2(*(b_pos - a_pos)[::-1])
+
+        q = self.orientation
+        yaw = math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y ** 2 + q.z ** 2))
+        if axis == 'y':
+            yaw += math.pi / 2
+        diff = math.atan2(math.sin(target_angle - yaw), math.cos(target_angle - yaw))
+        return abs(diff) < math.radians(threshold_deg), diff
+
+    def is_facing_x_or_y(self, pose_b):
+        """
+        Check if this pose is facing another pose along either the X or Y axis within a default angular threshold.
+
+        :param pose_b: The target pose to compare against.
+        :return: True if this pose is facing the target along either X or Y axis, False otherwise.
+        """
+
+        result = {a: self.is_facing_2d_axis(pose_b, axis=a) for a in ('x', 'y')}
+        return any(r[0] for r in result.values())
+
+    def get_rotation_offset_from_axis_preference(self, pose_b):
+        """
+        Compute a discrete rotation offset (-90 or 90 degrees) to align this pose's local axes with the direction
+        toward a target pose, based on which axis (X or Y) is more aligned.
+
+        :param pose_b: The target pose to align with.
+        :return: Tuple of (rotation offset in degrees, signed angle difference in radians for Y axis).
+        """
+        fx, ax = self.is_facing_2d_axis(pose_b, axis='x')
+        fy, ay = self.is_facing_2d_axis(pose_b, axis='y')
+
+        return (-90 if abs(ax) > abs(ay) else 90), ay
+
+
 
 
 @dataclass

--- a/src/pycrap/ontologies/crax/classes.py
+++ b/src/pycrap/ontologies/crax/classes.py
@@ -151,6 +151,12 @@ class CuttingTool(PhysicalObject):
     """
 
 
+class MixingTool(PhysicalObject):
+    """
+    The tool used for mixing — such as a Spoon, Whisk, or similar — depends on the specific task and object being processed.
+    """
+
+
 class Agent(Base):
     ...
 

--- a/src/pycrap/ontologies/crax/classes.py
+++ b/src/pycrap/ontologies/crax/classes.py
@@ -43,6 +43,14 @@ class Food(Base):
     ...
 
 
+class Fruit(Food):
+    ...
+
+
+class Apple(Fruit):
+    ...
+
+
 class Environment(Base):
     ...
 
@@ -134,6 +142,12 @@ class PhysicalObject(Base):
 class PouringTool(PhysicalObject):
     """
     The Tool that is used for pouring, can be cup, bottle, etc.
+    """
+
+
+class CuttingTool(PhysicalObject):
+    """
+    The tool used for cutting — such as a knife, bread-knife, or similar — depends on the specific task and object being processed.
     """
 
 

--- a/test/test_pose.py
+++ b/test/test_pose.py
@@ -1,5 +1,7 @@
+import math
 import unittest
 
+from datastructures.enums import AxisIdentifier
 from pycram.datastructures.pose import PoseStamped, TransformStamped, Quaternion, Vector3
 
 
@@ -88,12 +90,12 @@ class TestPose(unittest.TestCase):
         a = PoseStamped.from_list([0, 0, 0], [0, 0, 0, 1], "map")  # facing +x
         b = PoseStamped.from_list([1, 0, 0], [0, 0, 0, 1], "map")
 
-        facing, angle = a.is_facing_2d_axis(b, axis='x')
+        facing, angle = a.is_facing_2d_axis(b, axis=AxisIdentifier.X)
         self.assertTrue(facing)
         self.assertAlmostEqual(angle, 0, delta=1e-6)
 
         # now test Y alignment (should be 90 deg difference)
-        facing_y, angle_y = a.is_facing_2d_axis(b, axis='y')
+        facing_y, angle_y = a.is_facing_2d_axis(b, axis=AxisIdentifier.Y)
         self.assertFalse(facing_y)
         self.assertAlmostEqual(abs(angle_y), math.pi / 2, delta=1e-6)
 

--- a/test/test_pose.py
+++ b/test/test_pose.py
@@ -1,8 +1,7 @@
 import math
 import unittest
 
-from datastructures.enums import AxisIdentifier
-from pycram.datastructures.pose import PoseStamped, TransformStamped, Quaternion, Vector3
+from pycram.datastructures.pose import PoseStamped, TransformStamped, Quaternion, Vector3, AxisIdentifier
 
 
 class TestPose(unittest.TestCase):

--- a/test/test_pose.py
+++ b/test/test_pose.py
@@ -107,11 +107,3 @@ class TestPose(unittest.TestCase):
         # reverse direction
         b.position.x = -1
         self.assertFalse(a.is_facing_x_or_y(b))
-
-    def test_rotation_offset_from_axis_preference(self):
-        a = PoseStamped.from_list([0, 0, 0], [0, 0, 0, 1], "map")
-        b = PoseStamped.from_list([0, 1, 0], [0, 0, 0, 1], "map")  # upward in Y
-
-        angle, angle_y = a.get_rotation_offset_from_axis_preference(b)
-        self.assertEqual(angle, 90)
-        self.assertTrue(angle_y > 0)


### PR DESCRIPTION
This adds three new methods to PoseStamped that help with reasoning about orientation between poses in 2D space. The goal is to figure out whether one pose is "facing" another along its local X or Y axis and, based on that, compute a suggested rotation. Particular i need them for my cutting action

New methods:
**is_facing_2d_axis(pose_b, axis='x'):**
Checks if this pose is roughly facing pose_b along the specified axis (X or Y), within a default 82° threshold.

**is_facing_x_or_y(pose_b):**
Returns True if the pose is facing the target pose along either X or Y.

