### PR TITLE
Refactor imports to use the 'rx' module in probabilistic_model

### DIFF
--- a/examples/improving_actions.md
+++ b/examples/improving_actions.md
@@ -33,7 +33,7 @@ import pandas as pd
 import sqlalchemy.orm
 
 import plotly
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import ProbabilisticCircuit
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import ProbabilisticCircuit
 
 plotly.offline.init_notebook_mode()
 import plotly.graph_objects as go

--- a/src/pycram/costmaps.py
+++ b/src/pycram/costmaps.py
@@ -8,8 +8,8 @@ import numpy as np
 import psutil
 import random_events
 from matplotlib import colors
-from probabilistic_model.probabilistic_circuit.nx.helper import uniform_measure_of_event
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import ProbabilisticCircuit
+from probabilistic_model.probabilistic_circuit.rx.helper import uniform_measure_of_event
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import ProbabilisticCircuit
 from random_events.interval import Interval, reals, closed_open, closed
 from random_events.product_algebra import Event, SimpleEvent
 from random_events.variable import Continuous

--- a/src/pycram/designators/location_designator.py
+++ b/src/pycram/designators/location_designator.py
@@ -8,8 +8,8 @@ import tqdm
 from box import Box
 from probabilistic_model.distributions import DiracDeltaDistribution, GaussianDistribution
 from probabilistic_model.distributions.helper import make_dirac
-from probabilistic_model.probabilistic_circuit.nx.helper import uniform_measure_of_event, leaf
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import SumUnit, ProbabilisticCircuit, \
+from probabilistic_model.probabilistic_circuit.rx.helper import uniform_measure_of_event, leaf
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import SumUnit, ProbabilisticCircuit, \
     ProductUnit
 from probabilistic_model.probabilistic_model import ProbabilisticModel
 from random_events.interval import closed

--- a/src/pycram/designators/specialized_designators/probabilistic/probabilistic_action.py
+++ b/src/pycram/designators/specialized_designators/probabilistic/probabilistic_action.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from typing import Type
 
 from probabilistic_model.distributions import SymbolicDistribution
-from probabilistic_model.probabilistic_circuit.nx.helper import fully_factorized, leaf
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import ProbabilisticCircuit, SumUnit, \
+from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized, leaf
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import ProbabilisticCircuit, SumUnit, \
     ProductUnit
 from probabilistic_model.utils import MissingDict
 from random_events.product_algebra import SimpleEvent

--- a/src/pycram/parameterizer.py
+++ b/src/pycram/parameterizer.py
@@ -5,8 +5,8 @@ from enum import Enum
 from typing import Dict, Any, Type, List, Optional
 
 import numpy as np
-from probabilistic_model.probabilistic_circuit.nx.helper import fully_factorized
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import ProbabilisticCircuit
+from probabilistic_model.probabilistic_circuit.rx.helper import fully_factorized
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import ProbabilisticCircuit
 from probabilistic_model.probabilistic_model import ProbabilisticModel
 from random_events.interval import singleton
 from random_events.product_algebra import Event, SimpleEvent

--- a/src/pycram/probabilistic_costmap.py
+++ b/src/pycram/probabilistic_costmap.py
@@ -14,8 +14,8 @@ from .ros import create_publisher, Duration, loginfo
 from .units import meter
 
 from pint import Quantity
-from probabilistic_model.probabilistic_circuit.nx.helper import uniform_measure_of_event
-from probabilistic_model.probabilistic_circuit.nx.probabilistic_circuit import ProbabilisticCircuit
+from probabilistic_model.probabilistic_circuit.rx.helper import uniform_measure_of_event
+from probabilistic_model.probabilistic_circuit.rx.probabilistic_circuit import ProbabilisticCircuit
 from random_events.product_algebra import Event, SimpleEvent
 from random_events.variable import Continuous
 


### PR DESCRIPTION
A rename in probabilistic_model had caused import errors on a fresh install of PyCRAM.