### PR TITLE
Added iai_robots to ros2 dockerfile

### DIFF
--- a/docker/ros2/Dockerfile
+++ b/docker/ros2/Dockerfile
@@ -11,6 +11,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN apt update && apt install python3.12-venv ros-jazzy-xacro python3-vcstool git ros-dev-tools default-jre -y
 RUN vcs import --input https://raw.githubusercontent.com/cram2/pycram/dev/rosinstall/pycram-ros2-https.rosinstall
+RUN git clone -b ros-jazzy https://github.com/code-iai/iai_robots.git
 RUN source /opt/ros/jazzy/setup.bash && cd $OVERLAY_WS && colcon build --symlink-install
 RUN echo "source $OVERLAY_WS/install/setup.bash" >> ~/.bashrc
 


### PR DESCRIPTION
Added [iai_robots](https://github.com/code-iai/iai_robots.git) (branch: ros-jazzy) to ros2 dockerfile for CI/CD pipeline.

This is a preparation to multi-robot changes, as more robot models than the pr2 are required for sufficient testing 